### PR TITLE
move to operator specific namespace

### DIFF
--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_00_namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/run-level: "0"
-  name: openshift-core-operators
+  name: openshift-cluster-openshift-controller-manager-operator

--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_02_configmap.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_02_configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-controller-manager-operator
   name: openshift-cluster-openshift-controller-manager-operator-config
 data:
   config.yaml: |

--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_03_builder-deployer-config.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_03_builder-deployer-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-controller-manager-operator
   name: openshift-controller-manager-images
 data:
   builderImage: quay.io/openshift/origin-docker-builder:v4.0

--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_04_roles.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_04_roles.yaml
@@ -7,5 +7,5 @@ roleRef:
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-controller-manager-operator
   name: openshift-cluster-openshift-controller-manager-operator

--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_05_serviceaccount.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_05_serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-controller-manager-operator
   name: openshift-cluster-openshift-controller-manager-operator
   labels:
     app: openshift-cluster-openshift-controller-manager-operator

--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_07_deployment.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_07_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: openshift-core-operators
+  namespace: openshift-cluster-openshift-controller-manager-operator
   name: openshift-cluster-openshift-controller-manager-operator
   labels:
     app: openshift-cluster-openshift-controller-manager-operator

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -70,8 +70,8 @@ func RunOperator(clientConfig *rest.Config, stopCh <-chan struct{}) error {
 	)
 
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
-		"openshift-core-operators",
-		"openshift-controller-manager",
+		"openshift-cluster-openshift-controller-manager-operator",
+		"openshift-cluster-openshift-controller-manager-operator",
 		dynamicClient,
 		&operatorStatusProvider{informers: operatorConfigInformers},
 	)


### PR DESCRIPTION
Moves our namespace to openshift-cluster-openshift-controller-manager-operator and updates our ClusterOperator to match.  In combination with making the ClusterOperator cluster scoped, this allows the names of the ClusterOperator to match the namespace, image, and name of the operator it corresponds to.  This allows easy tracking and ensures that we don't have conflicts.

/assign @bparees 

