### PR TITLE
bindata: add memory request to openshift-controller-manager pod

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -28,6 +28,9 @@ spec:
         command: ["hypershift", "openshift-controller-manager"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
+        resources:
+          requests:
+            memory: 100Mi
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -133,6 +133,9 @@ spec:
         command: ["hypershift", "openshift-controller-manager"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
+        resources:
+          requests:
+            memory: 100Mi
         ports:
         - containerPort: 8443
         volumeMounts:


### PR DESCRIPTION
One in a series of PRs to set memory requests for all control plane and high memory use components.

We are encountering master instability (https://github.com/openshift/installer/pull/408 https://github.com/openshift/installer/pull/785) as the number of components increase because many components run `BestEffort` giving the scheduler no information on pod resource usage.

On a steady state empty cluster, `openshift-controller-manager` uses 85Mi.

{pod_name="controller-manager-6l25p"} | 84848640

Because it is a control plane component, I'm giving it a buffer and setting to `100Mi`

@deads2k @sttts  @derekwaynecarr



