### PR TITLE
manifests: add memory request to operator pod

### DIFF
--- a/manifests/0000_21_cluster-openshift-controller-manager-operator_07_deployment.yaml
+++ b/manifests/0000_21_cluster-openshift-controller-manager-operator_07_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         - "-v=4"
+        resources:
+          requests:
+            memory: 50Mi
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config


### PR DESCRIPTION
Follow on to the previous PR https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/45 setting memory limit for the operator pod.

{pod_name="openshift-cluster-openshift-controller-manager-operator-cbm59jt"}	29188096

Uses 30Mi in practice.  Setting to `50Mi` for some buffer.