### PR TITLE
remove references to operator v1alpha1 API

### DIFF
--- a/pkg/apis/openshiftcontrollermanager/v1/register.go
+++ b/pkg/apis/openshiftcontrollermanager/v1/register.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
-	operatorsv1alpha1api "github.com/openshift/api/operator/v1alpha1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -11,7 +11,7 @@ import (
 var (
 	GroupName     = "openshiftcontrollermanager.operator.openshift.io"
 	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1"}
-	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, configv1.Install, operatorsv1alpha1api.Install)
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, configv1.Install, operatorv1.Install)
 	// Install is a function which adds this version to a scheme
 	Install = schemeBuilder.AddToScheme
 

--- a/pkg/testframework/conditionhelper.go
+++ b/pkg/testframework/conditionhelper.go
@@ -8,9 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	osapi "github.com/openshift/api/config/v1"
-	operatorapi "github.com/openshift/api/operator/v1alpha1"
-
 	configv1 "github.com/openshift/api/config/v1"
 )
 
@@ -19,13 +16,13 @@ func hasExpectedClusterOperatorConditions(status *configv1.ClusterOperator) bool
 	gotProgressing := false
 	gotFailing := false
 	for _, c := range status.Status.Conditions {
-		if c.Type == operatorapi.OperatorStatusTypeAvailable && c.Status == osapi.ConditionTrue {
+		if c.Type == configv1.OperatorAvailable && c.Status == configv1.ConditionTrue {
 			gotAvailable = true
 		}
-		if c.Type == operatorapi.OperatorStatusTypeProgressing && c.Status == osapi.ConditionFalse {
+		if c.Type == configv1.OperatorProgressing && c.Status == configv1.ConditionFalse {
 			gotProgressing = true
 		}
-		if c.Type == operatorapi.OperatorStatusTypeFailing && c.Status == osapi.ConditionFalse {
+		if c.Type == configv1.OperatorFailing && c.Status == configv1.ConditionFalse {
 			gotFailing = true
 		}
 	}


### PR DESCRIPTION
Looks like this was missed in https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/42