### PR TITLE
no need for post-startup cache sync checks

### DIFF
--- a/pkg/operator/configobservation/builds/observe_builds.go
+++ b/pkg/operator/configobservation/builds/observe_builds.go
@@ -59,11 +59,6 @@ func ObserveBuildControllerConfig(genericListers configobserver.Listers, recorde
 		}
 	}
 
-	if !listers.BuildConfigSynced() {
-		glog.Warning("builds.config.openshift.io not synced")
-		return prevObservedConfig, errs
-	}
-
 	// now gather the cluster config and turn it into the observed config
 	observedConfig := map[string]interface{}{}
 	buildConfig, err := listers.BuildConfigLister.Get("cluster")

--- a/pkg/operator/configobservation/builds/observe_builds_test.go
+++ b/pkg/operator/configobservation/builds/observe_builds_test.go
@@ -184,7 +184,6 @@ func TestObserveBuildControllerConfig(t *testing.T) {
 			}
 			listers := configobservation.Listers{
 				BuildConfigLister: configlistersv1.NewBuildLister(indexer),
-				BuildConfigSynced: func() bool { return true },
 			}
 			config := map[string]interface{}{}
 			observed, err := ObserveBuildControllerConfig(listers, events.NewInMemoryRecorder(""), config)

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -32,12 +32,12 @@ func NewConfigObserver(
 			eventRecorder,
 			configobservation.Listers{
 				ImageConfigLister: configInformers.Config().V1().Images().Lister(),
-				ImageConfigSynced: configInformers.Config().V1().Images().Informer().HasSynced,
 				BuildConfigLister: configInformers.Config().V1().Builds().Lister(),
-				BuildConfigSynced: configInformers.Config().V1().Builds().Informer().HasSynced,
 				ConfigMapLister:   kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Lister(),
-				ConfigMapSynced:   kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
 				PreRunCachesSynced: []cache.InformerSynced{
+					configInformers.Config().V1().Images().Informer().HasSynced,
+					configInformers.Config().V1().Builds().Informer().HasSynced,
+					kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
 					configInformers.Config().V1().Images().Informer().HasSynced,
 					configInformers.Config().V1().Builds().Informer().HasSynced,
 					kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,

--- a/pkg/operator/configobservation/deployimages/observe_deployimages.go
+++ b/pkg/operator/configobservation/deployimages/observe_deployimages.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/configobserver"
 	"github.com/openshift/library-go/pkg/operator/events"
-
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation"
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/util"
 )
@@ -42,11 +41,6 @@ func ObserveControllerManagerImagesConfig(genericListers configobserver.Listers,
 		if err != nil {
 			return prevObservedConfig, append(errs, err)
 		}
-	}
-
-	if !listers.ConfigMapSynced() {
-		glog.Warning("configmaps not synced")
-		return prevObservedConfig, errs
 	}
 
 	// now gather the cluster config and turn it into the observed config

--- a/pkg/operator/configobservation/images/observe_images.go
+++ b/pkg/operator/configobservation/images/observe_images.go
@@ -31,11 +31,6 @@ func ObserveInternalRegistryHostname(genericListers configobserver.Listers, reco
 		}
 	}
 
-	if !listers.ImageConfigSynced() {
-		glog.Warning("images.config.openshift.io not synced")
-		return prevObservedConfig, errs
-	}
-
 	// now gather the cluster config and turn it into the observed config
 	observedConfig := map[string]interface{}{}
 	configImage, err := listers.ImageConfigLister.Get("cluster")

--- a/pkg/operator/configobservation/images/observe_images_test.go
+++ b/pkg/operator/configobservation/images/observe_images_test.go
@@ -31,7 +31,6 @@ func TestObserveRegistryConfig(t *testing.T) {
 
 	listers := configobservation.Listers{
 		ImageConfigLister: configlistersv1.NewImageLister(indexer),
-		ImageConfigSynced: func() bool { return true },
 	}
 
 	result, errs := ObserveInternalRegistryHostname(listers, events.NewInMemoryRecorder(""), map[string]interface{}{})

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -12,9 +12,6 @@ type Listers struct {
 	ImageConfigLister  configlistersv1.ImageLister
 	BuildConfigLister  configlistersv1.BuildLister
 	ConfigMapLister    corelistersv1.ConfigMapLister
-	ImageConfigSynced  cache.InformerSynced
-	BuildConfigSynced  cache.InformerSynced
-	ConfigMapSynced    cache.InformerSynced
 	PreRunCachesSynced []cache.InformerSynced
 }
 


### PR DESCRIPTION
No need for post-startup cache sync checks for CRDs now managed by **cluster-config-operator**.