### PR TITLE
rename controller operator resource instance from 'instance' to 'cluster'

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/operator-config.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/operator-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.openshift.io/v1
 kind: OpenShiftControllerManager
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hypershift:latest

--- a/pkg/operator/generic_client.go
+++ b/pkg/operator/generic_client.go
@@ -18,7 +18,7 @@ func (p *operatorClient) Informer() cache.SharedIndexInformer {
 }
 
 func (p *operatorClient) CurrentStatus() (operatorapiv1.OperatorStatus, error) {
-	instance, err := p.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("instance")
+	instance, err := p.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("cluster")
 	if err != nil {
 		return operatorapiv1.OperatorStatus{}, err
 	}
@@ -27,7 +27,7 @@ func (p *operatorClient) CurrentStatus() (operatorapiv1.OperatorStatus, error) {
 }
 
 func (c *operatorClient) GetOperatorState() (*operatorapiv1.OperatorSpec, *operatorapiv1.OperatorStatus, string, error) {
-	instance, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("instance")
+	instance, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -36,7 +36,7 @@ func (c *operatorClient) GetOperatorState() (*operatorapiv1.OperatorSpec, *opera
 }
 
 func (c *operatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorapiv1.OperatorSpec) (*operatorapiv1.OperatorSpec, string, error) {
-	original, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("instance")
+	original, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -52,7 +52,7 @@ func (c *operatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *operatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorapiv1.OperatorStatus) (*operatorapiv1.OperatorStatus, error) {
-	original, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("instance")
+	original, err := c.informers.Operator().V1().OpenShiftControllerManagers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -76,7 +76,7 @@ func NewOpenShiftControllerManagerOperator(
 }
 
 func (c OpenShiftControllerManagerOperator) sync() error {
-	operatorConfig, err := c.operatorConfigClient.OpenShiftControllerManagers().Get("instance", metav1.GetOptions{})
+	operatorConfig, err := c.operatorConfigClient.OpenShiftControllerManagers().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -101,7 +101,7 @@ func syncOpenShiftControllerManager_v311_00_to_latest(c OpenShiftControllerManag
 		progressingMessages = append(progressingMessages, fmt.Sprintf("daemonset/controller-manager: observed generation is %d, desired generation is %d.", actualDaemonSet.Status.ObservedGeneration, actualDaemonSet.ObjectMeta.Generation))
 	}
 	if operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration {
-		progressingMessages = append(progressingMessages, fmt.Sprintf("openshiftcontrollermanageroperatorconfigs/instance: observed generation is %d, desired generation is %d.", operatorConfig.Status.ObservedGeneration, operatorConfig.ObjectMeta.Generation))
+		progressingMessages = append(progressingMessages, fmt.Sprintf("openshiftcontrollermanagers.operator.openshift.io/cluster: observed generation is %d, desired generation is %d.", operatorConfig.Status.ObservedGeneration, operatorConfig.ObjectMeta.Generation))
 	}
 	if len(progressingMessages) == 0 {
 		v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorapiv1.OperatorCondition{

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -317,7 +317,7 @@ func v3110OpenshiftControllerManagerLeaderRolebindingYaml() (*asset, error) {
 var _v3110OpenshiftControllerManagerOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
 kind: OpenShiftControllerManager
 metadata:
-  name: instance
+  name: cluster
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hypershift:latest

--- a/test/e2e/cluster_openshift_controller_manager_operator_test.go
+++ b/test/e2e/cluster_openshift_controller_manager_operator_test.go
@@ -48,7 +48,7 @@ func TestClusterBuildConfigObservation(t *testing.T) {
 	}()
 
 	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		cfg, err := client.OpenShiftControllerManagers().Get("instance", metav1.GetOptions{})
+		cfg, err := client.OpenShiftControllerManagers().Get("cluster", metav1.GetOptions{})
 		if cfg == nil || err != nil {
 			t.Logf("error getting openshift controller manager config: %v", err)
 			return false, nil
@@ -71,7 +71,7 @@ func TestClusterImageConfigObservation(t *testing.T) {
 	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
 	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		cfg, err := client.OpenShiftControllerManagers().Get("instance", metav1.GetOptions{})
+		cfg, err := client.OpenShiftControllerManagers().Get("cluster", metav1.GetOptions{})
 		if cfg == nil || err != nil {
 			t.Logf("error getting openshift controller manager config: %v", err)
 			return false, nil


### PR DESCRIPTION
makes us consistent w/ the other controller+api operators.
