### PR TITLE
Update pod.yaml to include priorityClassName

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -20,6 +20,7 @@ spec:
         app: openshift-controller-manager
         controller-manager: "true"
     spec:
+      priorityClassName: system-node-critical 
       serviceAccountName: openshift-controller-manager-sa
       containers:
       - name: controller-manager

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -125,6 +125,7 @@ spec:
         app: openshift-controller-manager
         controller-manager: "true"
     spec:
+      priorityClassName: system-node-critical 
       serviceAccountName: openshift-controller-manager-sa
       containers:
       - name: controller-manager


### PR DESCRIPTION
As of now, priorityClass is not set for openshift-controller-manager:

`oc describe pod controller-manager-7t97k -n openshift-controller-manager | grep -i priority
Priority:           0
PriorityClassName:  <none>`

I am adding system-node-critical priorityClassName so that controlle-manager is in sync in other control plane components.