### PR TITLE
Drop etcd metrics

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
@@ -18,9 +18,6 @@ spec:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-controller-manager-operator.svc
   jobLabel: component
-  namespaceSelector:
-    matchNames:
-    - openshift-controller-manager-operator
   selector:
     matchLabels:
       app: openshift-controller-manager-operator

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -17,7 +17,4 @@ spec:
       regex: etcd_(debugging|disk|request|server).*
       sourceLabels:
       - __name__
-  namespaceSelector:
-    matchNames:
-    - openshift-controller-manager
   selector: {}

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -12,6 +12,11 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: controller-manager.openshift-controller-manager.svc
+    metricRelabelings:
+    - action: drop
+      regex: etcd_(debugging|disk|request|server).*
+      sourceLabels:
+      - __name__
   namespaceSelector:
     matchNames:
     - openshift-controller-manager


### PR DESCRIPTION
This pull request drops accidentally instrumented etcd metrics (more description in the commit message) and removes the `namespaceSelector` fields as it defaults to the namespace the `ServiceMonitor` object is in, therefore what was previously in the `ServiceMonitor` objects is already the default, so just removing unnecessary mental overhead when reading the object.

@bparees @mfojtik @smarterclayton 