### PR TITLE
use system-cluster-critical priority

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -53,5 +53,6 @@ spec:
           secretName: serving-cert
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/manifests/0000_63_openshift-controller-manager-operator_09_deployment.yaml
+++ b/manifests/0000_63_openshift-controller-manager-operator_09_deployment.yaml
@@ -57,5 +57,6 @@ spec:
           name: openshift-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -158,6 +158,7 @@ spec:
           secretName: serving-cert
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
 `)


### PR DESCRIPTION
specifies system-cluster-critical priority for operator and operand
blocks passing smoke tests for ensuring control plane pods always schedule.

see: openshift/origin#22217