### PR TITLE
Use the CVO for operator config management

### DIFF
--- a/manifests/0000_63_openshift-controller-manager-operator_03_config.cr.yaml
+++ b/manifests/0000_63_openshift-controller-manager-operator_03_config.cr.yaml
@@ -2,6 +2,8 @@ apiVersion: operator.openshift.io/v1
 kind: OpenShiftControllerManager
 metadata:
   name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
   imagePullSpec: openshift/origin-hypershift:latest

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,25 +6,19 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorapiv1 "github.com/openshift/api/operator/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
+	configobservationcontroller "github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/configobservercontroller"
+	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/util"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/status"
-	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	configobservationcontroller "github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/configobservercontroller"
-	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/v311_00_assets"
-	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/util"
 )
 
 func RunOperator(ctx *controllercmd.ControllerContext) error {
@@ -36,20 +30,10 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-	dynamicClient, err := dynamic.NewForConfig(ctx.KubeConfig)
-	if err != nil {
-		return err
-	}
 	configClient, err := configclient.NewForConfig(ctx.KubeConfig)
 	if err != nil {
 		return err
 	}
-
-	v1helpers.EnsureOperatorConfigExists(
-		dynamicClient,
-		v311_00_assets.MustAsset("v3.11.0/openshift-controller-manager/operator-config.yaml"),
-		schema.GroupVersionResource{Group: operatorapiv1.GroupName, Version: "v1", Resource: "openshiftcontrollermanagers"},
-	)
 
 	operatorConfigInformers := operatorinformers.NewSharedInformerFactory(operatorClient, 10*time.Minute)
 	kubeInformersForOpenshiftControllerManagerNamespace := informers.NewSharedInformerFactoryWithOptions(kubeClient, 10*time.Minute, informers.WithNamespace(util.TargetNamespace))

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -7,7 +7,6 @@
 // bindata/v3.11.0/openshift-controller-manager/informer-clusterrolebinding.yaml
 // bindata/v3.11.0/openshift-controller-manager/leader-role.yaml
 // bindata/v3.11.0/openshift-controller-manager/leader-rolebinding.yaml
-// bindata/v3.11.0/openshift-controller-manager/operator-config.yaml
 // bindata/v3.11.0/openshift-controller-manager/sa.yaml
 // bindata/v3.11.0/openshift-controller-manager/separate-sa-role.yaml
 // bindata/v3.11.0/openshift-controller-manager/separate-sa-rolebinding.yaml
@@ -324,34 +323,6 @@ func v3110OpenshiftControllerManagerLeaderRolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v3110OpenshiftControllerManagerOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
-kind: OpenShiftControllerManager
-metadata:
-  name: cluster
-spec:
-  managementState: Managed
-  imagePullSpec: openshift/origin-hypershift:latest
-  version: 3.11.0
-  logging:
-    level: 4
-  replicas: 2
-`)
-
-func v3110OpenshiftControllerManagerOperatorConfigYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftControllerManagerOperatorConfigYaml, nil
-}
-
-func v3110OpenshiftControllerManagerOperatorConfigYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftControllerManagerOperatorConfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-controller-manager/operator-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _v3110OpenshiftControllerManagerSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -661,7 +632,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-controller-manager/informer-clusterrolebinding.yaml":    v3110OpenshiftControllerManagerInformerClusterrolebindingYaml,
 	"v3.11.0/openshift-controller-manager/leader-role.yaml":                    v3110OpenshiftControllerManagerLeaderRoleYaml,
 	"v3.11.0/openshift-controller-manager/leader-rolebinding.yaml":             v3110OpenshiftControllerManagerLeaderRolebindingYaml,
-	"v3.11.0/openshift-controller-manager/operator-config.yaml":                v3110OpenshiftControllerManagerOperatorConfigYaml,
 	"v3.11.0/openshift-controller-manager/sa.yaml":                             v3110OpenshiftControllerManagerSaYaml,
 	"v3.11.0/openshift-controller-manager/separate-sa-role.yaml":               v3110OpenshiftControllerManagerSeparateSaRoleYaml,
 	"v3.11.0/openshift-controller-manager/separate-sa-rolebinding.yaml":        v3110OpenshiftControllerManagerSeparateSaRolebindingYaml,
@@ -722,7 +692,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"informer-clusterrolebinding.yaml":    {v3110OpenshiftControllerManagerInformerClusterrolebindingYaml, map[string]*bintree{}},
 			"leader-role.yaml":                    {v3110OpenshiftControllerManagerLeaderRoleYaml, map[string]*bintree{}},
 			"leader-rolebinding.yaml":             {v3110OpenshiftControllerManagerLeaderRolebindingYaml, map[string]*bintree{}},
-			"operator-config.yaml":                {v3110OpenshiftControllerManagerOperatorConfigYaml, map[string]*bintree{}},
 			"sa.yaml":                             {v3110OpenshiftControllerManagerSaYaml, map[string]*bintree{}},
 			"separate-sa-role.yaml":               {v3110OpenshiftControllerManagerSeparateSaRoleYaml, map[string]*bintree{}},
 			"separate-sa-rolebinding.yaml":        {v3110OpenshiftControllerManagerSeparateSaRolebindingYaml, map[string]*bintree{}},


### PR DESCRIPTION
Don't create operator resource with EnsureOperatorConfigExists, which is being removed, and instead tag the manifest to be managed by the CVO