### PR TITLE
Global proxy builds

### DIFF
--- a/pkg/operator/configobservation/builds/observe_builds.go
+++ b/pkg/operator/configobservation/builds/observe_builds.go
@@ -70,27 +70,8 @@ func ObserveBuildControllerConfig(genericListers configobserver.Listers, recorde
 		return prevObservedConfig, append(errs, err)
 	}
 
-	gitProxy := buildConfig.Spec.BuildDefaults.GitProxy
-	// note, default proxy is used for git proxy if git proxy is not set.
-	// default proxy is also used for builds to pull images, but that configuration
-	// is setup by the build controller reading the build cluster config directly,
-	// this operator does not need to pass it to the controller process configuration.
-	defaultProxy := buildConfig.Spec.BuildDefaults.DefaultProxy
-	if gitProxy == nil {
-		gitProxy = defaultProxy
-	}
-
-	if gitProxy != nil {
-		if err = configobservation.ObserveField(observedConfig, gitProxy.HTTPProxy, "build.buildDefaults.gitHTTPProxy", false); err != nil {
-			return nil, append(errs, fmt.Errorf("failed to observe %s: %v", "build.buildDefaults.gitHTTPProxy", err))
-		}
-		if err = configobservation.ObserveField(observedConfig, gitProxy.HTTPSProxy, "build.buildDefaults.gitHTTPSProxy", false); err != nil {
-			return nil, append(errs, fmt.Errorf("failed to observe %s: %v", "build.buildDefaults.gitHTTPSProxy", err))
-		}
-		if err = configobservation.ObserveField(observedConfig, gitProxy.NoProxy, "build.buildDefaults.gitNoProxy", false); err != nil {
-			return nil, append(errs, fmt.Errorf("failed to observe %s: %v", "build.buildDefaults.gitNoProxy", err))
-		}
-	}
+	// NOTE proxies are now entirely handled by the build controller itself;
+	// but we still process the other defaults/overrides cluster config for builds here
 
 	if len(buildConfig.Spec.BuildDefaults.Env) > 0 {
 		if err = configobservation.ObserveField(observedConfig, buildConfig.Spec.BuildDefaults.Env, "build.buildDefaults.env", true); err != nil {

--- a/pkg/operator/configobservation/builds/observe_builds_test.go
+++ b/pkg/operator/configobservation/builds/observe_builds_test.go
@@ -215,19 +215,9 @@ func TestObserveBuildControllerConfig(t *testing.T) {
 			testNestedField(observed, test.buildConfig.Spec.BuildOverrides.NodeSelector, "build.buildOverrides.nodeSelector", false, t)
 			testNestedField(observed, test.buildConfig.Spec.BuildOverrides.Tolerations, "build.buildOverrides.tolerations", false, t)
 
-			expectedGitProxy := test.buildConfig.Spec.BuildDefaults.DefaultProxy
-			if test.buildConfig.Spec.BuildDefaults.GitProxy != nil {
-				expectedGitProxy = test.buildConfig.Spec.BuildDefaults.GitProxy
-			}
-			if expectedGitProxy != nil {
-				testNestedField(observed, expectedGitProxy.HTTPProxy, "build.buildDefaults.gitHTTPProxy", true, t)
-				testNestedField(observed, expectedGitProxy.HTTPSProxy, "build.buildDefaults.gitHTTPSProxy", true, t)
-				testNestedField(observed, expectedGitProxy.NoProxy, "build.buildDefaults.gitNoProxy", true, t)
-			} else {
-				testNestedField(observed, nil, "build.buildDefaults.gitHTTPProxy", false, t)
-				testNestedField(observed, nil, "build.buildDefaults.gitHTTPSProxy", false, t)
-				testNestedField(observed, nil, "build.buildDefaults.gitNoProxy", false, t)
-			}
+			testNestedField(observed, nil, "build.buildDefaults.gitHTTPProxy", false, t)
+			testNestedField(observed, nil, "build.buildDefaults.gitHTTPSProxy", false, t)
+			testNestedField(observed, nil, "build.buildDefaults.gitNoProxy", false, t)
 		})
 	}
 }


### PR DESCRIPTION
https://jira.coreos.com/browse/DEVEXP-363

/assign @adambkaplan 

a sanity check at the moment to confirm I fully understood the outcome from today's call ... minimally I would think we do not merge this until the associated build controller changes drop

/hold

@openshift/sig-developer-experience fyi

also with the changing of gears from this morning, the glide bump is not necessary, but I left it in there as presumably it is benign ... but can rebase/remove as needed
