### PR TITLE
Configure the Service Ingress IP Controller (AutoExternalIPs) 

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/builds"
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/deployimages"
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/images"
+	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation/network"
 )
 
 type ConfigObserver struct {
@@ -33,10 +34,12 @@ func NewConfigObserver(
 			configobservation.Listers{
 				ImageConfigLister: configInformers.Config().V1().Images().Lister(),
 				BuildConfigLister: configInformers.Config().V1().Builds().Lister(),
+				NetworkLister:     configInformers.Config().V1().Networks().Lister(),
 				ConfigMapLister:   kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Lister(),
 				PreRunCachesSynced: []cache.InformerSynced{
 					configInformers.Config().V1().Images().Informer().HasSynced,
 					configInformers.Config().V1().Builds().Informer().HasSynced,
+					configInformers.Config().V1().Networks().Informer().HasSynced,
 					kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
 					configInformers.Config().V1().Images().Informer().HasSynced,
 					configInformers.Config().V1().Builds().Informer().HasSynced,
@@ -45,6 +48,7 @@ func NewConfigObserver(
 			},
 			images.ObserveInternalRegistryHostname,
 			builds.ObserveBuildControllerConfig,
+			network.ObserveExternalIPAutoAssignCIDRs,
 			deployimages.ObserveControllerManagerImagesConfig,
 		),
 	}
@@ -52,6 +56,7 @@ func NewConfigObserver(
 	kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().AddEventHandler(c.EventHandler())
 	configInformers.Config().V1().Images().Informer().AddEventHandler(c.EventHandler())
 	configInformers.Config().V1().Builds().Informer().AddEventHandler(c.EventHandler())
+	configInformers.Config().V1().Networks().Informer().AddEventHandler(c.EventHandler())
 
 	return c
 }

--- a/pkg/operator/configobservation/interfaces.go
+++ b/pkg/operator/configobservation/interfaces.go
@@ -12,6 +12,7 @@ type Listers struct {
 	ImageConfigLister  configlistersv1.ImageLister
 	BuildConfigLister  configlistersv1.BuildLister
 	ConfigMapLister    corelistersv1.ConfigMapLister
+	NetworkLister      configlistersv1.NetworkLister
 	PreRunCachesSynced []cache.InformerSynced
 }
 

--- a/pkg/operator/configobservation/network/observe_network.go
+++ b/pkg/operator/configobservation/network/observe_network.go
@@ -1,0 +1,53 @@
+package network
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/operator/configobserver"
+	"github.com/openshift/library-go/pkg/operator/configobserver/network"
+	"github.com/openshift/library-go/pkg/operator/events"
+
+	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation"
+)
+
+// ObserveExternalIPAutoAssignCIDRs watches the
+// config.openshift.io/v1/Network.Spec.ExternalIP.AutoAssignCIDRs field and
+// configures the IngressController accordingly.
+// The IngressController is a bit of a misnomer - it automatically allocates ExternalIPs
+// to Services of type LoadBalancer. It is useful for ingressing traffic to bare-metal.
+func ObserveExternalIPAutoAssignCIDRs(genericListers configobserver.Listers, recorder events.Recorder, existingConfig map[string]interface{}) (map[string]interface{}, []error) {
+	listers := genericListers.(configobservation.Listers)
+	out := map[string]interface{}{}
+
+	configPath := []string{"ingress", "ingressIPNetworkCIDR"}
+	prevValue, ok, err := unstructured.NestedString(existingConfig, configPath...)
+
+	// Preserve the existing value, so we can return it if we encounter an error
+	if err == nil && ok {
+		err = unstructured.SetNestedField(out, prevValue, configPath...)
+	}
+	if err != nil { // unlikely
+		return out, []error{err}
+	}
+
+	cidrs, err := network.GetExternalIPAutoAssignCIDRs(listers.NetworkLister, recorder)
+	if err != nil {
+		return out, []error{err}
+	}
+
+	if len(cidrs) == 0 {
+		err = unstructured.SetNestedField(out, "", configPath...)
+	} else if len(cidrs) == 1 {
+		err = unstructured.SetNestedField(out, cidrs[0], configPath...)
+	} else {
+		err = fmt.Errorf("error reading networks.%s/cluster Spec.ExternalIP.AutoAssignCIDRs: only one CIDR is supported", configv1.GroupName)
+	}
+
+	if err != nil {
+		return out, []error{err}
+	}
+	return out, nil
+}

--- a/pkg/operator/configobservation/network/observe_network_test.go
+++ b/pkg/operator/configobservation/network/observe_network_test.go
@@ -1,0 +1,100 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/openshift/library-go/pkg/operator/events"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation"
+)
+
+func TestObserveExternalIPAutoAssignCIDRs(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	recorder := events.NewInMemoryRecorder("")
+
+	listers := configobservation.Listers{
+		NetworkLister: configlistersv1.NewNetworkLister(indexer),
+	}
+
+	configPath := []string{"ingress", "ingressIPNetworkCIDR"}
+
+	expectValue := func(v string, result map[string]interface{}) {
+		t.Helper()
+		val, _, err := unstructured.NestedString(result, configPath...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != v {
+			t.Errorf("expected %q, got %q", v, val)
+		}
+	}
+
+	result, errs := ObserveExternalIPAutoAssignCIDRs(listers, recorder, map[string]interface{}{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors: %v", errs)
+	}
+	expectValue("", result)
+
+	err := indexer.Add(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.NetworkSpec{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, errs = ObserveExternalIPAutoAssignCIDRs(listers, recorder, map[string]interface{}{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors: %v", errs)
+	}
+	expectValue("", result)
+
+	err = indexer.Update(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.NetworkSpec{
+			ExternalIP: &configv1.ExternalIPConfig{
+				AutoAssignCIDRs: []string{"1.2.3.0/24"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, errs = ObserveExternalIPAutoAssignCIDRs(listers, recorder, map[string]interface{}{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors: %v", errs)
+	}
+	expectValue("1.2.3.0/24", result)
+
+	// save this result, make invalid, ensure old result preserved
+	oldResult := result
+	err = indexer.Update(&configv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.NetworkSpec{
+			ExternalIP: &configv1.ExternalIPConfig{
+				AutoAssignCIDRs: []string{"invalid"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, errs = ObserveExternalIPAutoAssignCIDRs(listers, recorder, oldResult)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error: %v", errs)
+	}
+	expectValue("1.2.3.0/24", result)
+}


### PR DESCRIPTION
This adds a Network configuration observer that populates the value in ingress.ingressIPNetworkCIDR.

This is used to automatically allocate the Service.ExternalIP field for services of type LoadBalancer.