### PR TITLE
Bug 1730719: Respecting resource limits and requests during build.

### DIFF
--- a/pkg/operator/configobservation/builds/observe_builds.go
+++ b/pkg/operator/configobservation/builds/observe_builds.go
@@ -84,6 +84,10 @@ func ObserveBuildControllerConfig(genericListers configobserver.Listers, recorde
 		}
 	}
 
+	if err = configobservation.ObserveField(observedConfig, buildConfig.Spec.BuildDefaults.Resources, "build.buildDefaults.resources", true); err != nil {
+		return nil, append(errs, fmt.Errorf("failed to observe %s: %v", "build.buildDefaults.resources", err))
+	}
+
 	// set build overrides
 	if len(buildConfig.Spec.BuildOverrides.ImageLabels) > 0 {
 		if err = configobservation.ObserveField(observedConfig, buildConfig.Spec.BuildOverrides.ImageLabels, "build.buildOverrides.imageLabels", true); err != nil {

--- a/pkg/operator/configobservation/builds/observe_builds_test.go
+++ b/pkg/operator/configobservation/builds/observe_builds_test.go
@@ -32,6 +32,26 @@ func TestObserveBuildControllerConfig(t *testing.T) {
 			name: "no build config",
 		},
 		{
+			name: "valid build config with resource limits",
+			buildConfig: &configv1.Build{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: configv1.BuildSpec{
+					BuildDefaults: configv1.BuildDefaults{
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: memLimit,
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: memLimit,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "valid build config",
 			buildConfig: &configv1.Build{
 				ObjectMeta: metav1.ObjectMeta{
@@ -211,6 +231,7 @@ func TestObserveBuildControllerConfig(t *testing.T) {
 			expectedEnv := test.buildConfig.Spec.BuildDefaults.Env
 			testNestedField(observed, expectedEnv, "build.buildDefaults.env", false, t)
 			testNestedField(observed, test.buildConfig.Spec.BuildDefaults.ImageLabels, "build.buildDefaults.imageLabels", false, t)
+			testNestedField(observed, test.buildConfig.Spec.BuildDefaults.Resources, "build.buildDefaults.resources", false, t)
 			testNestedField(observed, test.buildConfig.Spec.BuildOverrides.ImageLabels, "build.buildOverrides.imageLabels", false, t)
 			testNestedField(observed, test.buildConfig.Spec.BuildOverrides.NodeSelector, "build.buildOverrides.nodeSelector", false, t)
 			testNestedField(observed, test.buildConfig.Spec.BuildOverrides.Tolerations, "build.buildOverrides.tolerations", false, t)

--- a/pkg/operator/configobservation/util_test.go
+++ b/pkg/operator/configobservation/util_test.go
@@ -1,0 +1,86 @@
+package configobservation
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConvertJSON(t *testing.T) {
+	testObject := struct {
+		Value0 string  `json:"value0"`
+		Value1 int     `json:"value1"`
+		Value2 float64 `json:"value2"`
+	}{"value 0", 1, 4.2}
+
+	for _, tt := range []struct {
+		name         string
+		object       interface{}
+		expectsError bool
+		expected     interface{}
+	}{
+		{
+			name:     "nil",
+			object:   nil,
+			expected: nil,
+		},
+		{
+			name:         "integer",
+			object:       10,
+			expectsError: true,
+			expected:     nil,
+		},
+		{
+			name:         "string",
+			object:       "a simple string",
+			expectsError: true,
+			expected:     nil,
+		},
+		{
+			name:     "a slice of strings",
+			object:   []string{"a", "b", "c"},
+			expected: []interface{}{"a", "b", "c"},
+		},
+		{
+			name:     "a slice of integers",
+			object:   []int{1, 2, 3},
+			expected: []interface{}{float64(1), float64(2), float64(3)},
+		},
+		{
+			name:   "a struct",
+			object: testObject,
+			expected: map[string]interface{}{
+				"value0": "value 0",
+				"value1": float64(1),
+				"value2": 4.2,
+			},
+		},
+		{
+			name: "a map",
+			object: map[string]string{
+				"prop0": "0",
+				"prop1": "1",
+				"prop2": "2",
+			},
+			expected: map[string]interface{}{
+				"prop0": "0",
+				"prop1": "1",
+				"prop2": "2",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ConvertJSON(tt.object)
+			if tt.expectsError && err == nil {
+				t.Error("expected error, nil received instead")
+			}
+
+			if !tt.expectsError && err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
+
+			if !reflect.DeepEqual(res, tt.expected) {
+				t.Errorf("expected to be %v, got %v", tt.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch restores the functionality of restricting how much resources
a build can consume. Some extra test cases got added to validate the
functionality. To fix the problem function ConvertJSON() had to be
adapted to support maps also.

Tests added for ConvertJSON() function were designed with the old
behavior in mind as this function used to work only for slices fail
with anything else.