### PR TITLE
create configmap for global ca injection for use by builds

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/openshift-global-ca-cm.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/openshift-global-ca-cm.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openshift-global-ca
+  namespace: openshift-controller-manager
+  labels: 
+    config.openshift.io/inject-trusted-cabundle: "true"
+data: {}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -9,6 +9,7 @@
 // bindata/v3.11.0/openshift-controller-manager/leader-rolebinding.yaml
 // bindata/v3.11.0/openshift-controller-manager/old-leader-role.yaml
 // bindata/v3.11.0/openshift-controller-manager/old-leader-rolebinding.yaml
+// bindata/v3.11.0/openshift-controller-manager/openshift-global-ca-cm.yaml
 // bindata/v3.11.0/openshift-controller-manager/openshift-service-ca-cm.yaml
 // bindata/v3.11.0/openshift-controller-manager/sa.yaml
 // bindata/v3.11.0/openshift-controller-manager/separate-sa-role.yaml
@@ -390,6 +391,31 @@ func v3110OpenshiftControllerManagerOldLeaderRolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYaml = []byte(`kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openshift-global-ca
+  namespace: openshift-controller-manager
+  labels: 
+    config.openshift.io/inject-trusted-cabundle: "true"
+data: {}
+`)
+
+func v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYamlBytes() ([]byte, error) {
+	return _v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYaml, nil
+}
+
+func v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYaml() (*asset, error) {
+	bytes, err := v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v3.11.0/openshift-controller-manager/openshift-global-ca-cm.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v3110OpenshiftControllerManagerOpenshiftServiceCaCmYaml = []byte(`kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -726,6 +752,7 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-controller-manager/leader-rolebinding.yaml":             v3110OpenshiftControllerManagerLeaderRolebindingYaml,
 	"v3.11.0/openshift-controller-manager/old-leader-role.yaml":                v3110OpenshiftControllerManagerOldLeaderRoleYaml,
 	"v3.11.0/openshift-controller-manager/old-leader-rolebinding.yaml":         v3110OpenshiftControllerManagerOldLeaderRolebindingYaml,
+	"v3.11.0/openshift-controller-manager/openshift-global-ca-cm.yaml":         v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYaml,
 	"v3.11.0/openshift-controller-manager/openshift-service-ca-cm.yaml":        v3110OpenshiftControllerManagerOpenshiftServiceCaCmYaml,
 	"v3.11.0/openshift-controller-manager/sa.yaml":                             v3110OpenshiftControllerManagerSaYaml,
 	"v3.11.0/openshift-controller-manager/separate-sa-role.yaml":               v3110OpenshiftControllerManagerSeparateSaRoleYaml,
@@ -789,6 +816,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"leader-rolebinding.yaml":             {v3110OpenshiftControllerManagerLeaderRolebindingYaml, map[string]*bintree{}},
 			"old-leader-role.yaml":                {v3110OpenshiftControllerManagerOldLeaderRoleYaml, map[string]*bintree{}},
 			"old-leader-rolebinding.yaml":         {v3110OpenshiftControllerManagerOldLeaderRolebindingYaml, map[string]*bintree{}},
+			"openshift-global-ca-cm.yaml":         {v3110OpenshiftControllerManagerOpenshiftGlobalCaCmYaml, map[string]*bintree{}},
 			"openshift-service-ca-cm.yaml":        {v3110OpenshiftControllerManagerOpenshiftServiceCaCmYaml, map[string]*bintree{}},
 			"sa.yaml":                             {v3110OpenshiftControllerManagerSaYaml, map[string]*bintree{}},
 			"separate-sa-role.yaml":               {v3110OpenshiftControllerManagerSeparateSaRoleYaml, map[string]*bintree{}},


### PR DESCRIPTION
/assign @bparees 

@openshift/openshift-team-developer-experience FYI

per recent discussion on devex and warroom-proxy slack around https://bugzilla.redhat.com/show_bug.cgi?id=1748271

This would provide for an optimization in build controller

build controller in openshift-controller-manager could then just read in this data like it does for the service serving CA vs. labelling the config map it creates for mounting in the build pod