### PR TITLE
monitoring: move service monitor RBAC rules to manifests/

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -1,3 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
These are deployed by monitoring operator, but shouldn't: https://github.com/openshift/cluster-monitoring-operator/blob/e515ed03618466b6a1b9d2fcf12192191bfd90f8/assets/prometheus-k8s/role-specific-namespaces.yaml#L51-L66