### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
@@ -4,6 +4,8 @@ metadata:
   # TODO this should be a clusterrole
   name: prometheus-k8s
   namespace: openshift-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -20,6 +22,8 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s
   namespace: openshift-controller-manager
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/01_operand-namespace.yaml
+++ b/manifests/01_operand-namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-controller-manager
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/03_config.cr.yaml
+++ b/manifests/03_config.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     release.openshift.io/create-only: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   managementState: Managed

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   namespace: openshift-controller-manager-operator
   name: openshift-controller-manager-operator-config
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/05_builder-deployer-config.yaml
+++ b/manifests/05_builder-deployer-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   namespace: openshift-controller-manager-operator
   name: openshift-controller-manager-images
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   builderImage: quay.io/openshift/origin-docker-builder:v4.0
   deployerImage: quay.io/openshift/origin-deployer:v4.0

--- a/manifests/06_roles.yaml
+++ b/manifests/06_roles.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:openshift-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/07_serviceaccount.yaml
+++ b/manifests/07_serviceaccount.yaml
@@ -5,3 +5,5 @@ metadata:
   name: openshift-controller-manager-operator
   labels:
     app: openshift-controller-manager-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.