### PR TITLE
Bug 1804432: Fallback to logs on ocm termination

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -35,6 +35,7 @@ spec:
             cpu: 100m
         ports:
         - containerPort: 8443
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -143,6 +143,7 @@ spec:
             cpu: 100m
         ports:
         - containerPort: 8443
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config


### PR DESCRIPTION
Update ocm's DaemonSet to fallback to logs on failed termination.