### PR TITLE
Bug 1806913: Remove run-level for OCM and operator

### DIFF
--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -4,6 +4,5 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
   name: openshift-controller-manager-operator

--- a/manifests/01_operand-namespace.yaml
+++ b/manifests/01_operand-namespace.yaml
@@ -5,5 +5,4 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
The openshift-controller-manager and operator do not need to have run-level set.
Normal admission controller rules should be followed.