### PR TITLE
Bug 1805168: inject global proxy envs,ca into OCM daemonset

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -45,6 +45,8 @@ spec:
           name: client-ca
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: proxy-ca-bundles
       volumes:
       - name: config
         configMap:
@@ -55,8 +57,13 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+      - name: proxy-ca-bundles
+        configMap:
+          name: openshift-global-ca
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
       nodeSelector:
         node-role.kubernetes.io/master: ""
-      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -44,6 +44,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	operator := NewOpenShiftControllerManagerOperator(
 		os.Getenv("IMAGE"),
 		operatorConfigInformers.Operator().V1().OpenShiftControllerManagers(),
+		configInformers.Config().V1().Proxies(),
 		kubeInformersForOpenshiftControllerManagerNamespace,
 		operatorClient.OperatorV1(),
 		kubeClient,

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
@@ -1,6 +1,9 @@
 package operator
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"k8s.io/client-go/tools/cache"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -157,6 +160,9 @@ func TestProgressingCondition(t *testing.T) {
 					},
 				})
 
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			proxyLister := configlistersv1.NewProxyLister(indexer)
+
 			operatorConfig := &operatorv1.OpenShiftControllerManager{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "cluster",
@@ -175,6 +181,7 @@ func TestProgressingCondition(t *testing.T) {
 
 			operator := OpenShiftControllerManagerOperator{
 				kubeClient:           kubeClient,
+				proxyLister:          proxyLister,
 				recorder:             events.NewInMemoryRecorder(""),
 				operatorConfigClient: controllerManagerOperatorClient.OperatorV1(),
 			}
@@ -200,4 +207,94 @@ func TestProgressingCondition(t *testing.T) {
 		})
 	}
 
+}
+
+func TestDeploymentWithProxy(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset(
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "controller-manager",
+				Namespace:  "openshift-controller-manager",
+				Generation: 2,
+			},
+		},
+	)
+	dsClient := kubeClient.AppsV1()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	proxyConfig := &configv1.Proxy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1.ProxySpec{
+			NoProxy:    "no-proxy",
+			HTTPProxy:  "http://my-proxy",
+			HTTPSProxy: "https://my-proxy",
+		},
+		Status: configv1.ProxyStatus{
+			NoProxy:    "no-proxy",
+			HTTPProxy:  "http://my-proxy",
+			HTTPSProxy: "https://my-proxy"},
+	}
+	indexer.Add(proxyConfig)
+	proxyLister := configlistersv1.NewProxyLister(indexer)
+	recorder := events.NewInMemoryRecorder("")
+	operatorConfig := &operatorv1.OpenShiftControllerManager{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "cluster",
+			Generation: 2,
+		},
+		Spec: operatorv1.OpenShiftControllerManagerSpec{
+			OperatorSpec: operatorv1.OperatorSpec{},
+		},
+		Status: operatorv1.OpenShiftControllerManagerStatus{
+			OperatorStatus: operatorv1.OperatorStatus{
+				ObservedGeneration: 2,
+			},
+		},
+	}
+
+	ds, rcBool, err := manageOpenShiftControllerManagerDeployment_v311_00_to_latest(dsClient, recorder, operatorConfig, "my.co/repo/img:latest", operatorConfig.Status.Generations, false, proxyLister)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	if !rcBool {
+		t.Fatal("apply daemon set does not think a changes was made")
+	}
+
+	if ds == nil {
+		t.Fatalf("nil daemonset returned")
+	}
+
+	foundNoProxy := false
+	foundHTTPProxy := false
+	foundHTTPSProxy := false
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			switch e.Name {
+			case "NO_PROXY":
+				if e.Value == proxyConfig.Status.NoProxy {
+					foundNoProxy = true
+				}
+			case "HTTP_PROXY":
+				if e.Value == proxyConfig.Status.HTTPProxy {
+					foundHTTPProxy = true
+				}
+			case "HTTPS_PROXY":
+				if e.Value == proxyConfig.Status.HTTPSProxy {
+					foundHTTPSProxy = true
+				}
+			}
+		}
+	}
+
+	if !foundNoProxy {
+		t.Fatalf("NO_PROXY not found: %#v", ds.Spec.Template.Spec.Containers)
+	}
+	if !foundHTTPProxy {
+		t.Fatalf("HTTP_PROXY not found: %#v", ds.Spec.Template.Spec.Containers)
+	}
+	if !foundHTTPSProxy {
+		t.Fatalf("HTTPS_PROXY not found: %#v", ds.Spec.Template.Spec.Containers)
+	}
 }

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -153,6 +153,8 @@ spec:
           name: client-ca
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: proxy-ca-bundles
       volumes:
       - name: config
         configMap:
@@ -163,9 +165,14 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+      - name: proxy-ca-bundles
+        configMap:
+          name: openshift-global-ca
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
       nodeSelector:
         node-role.kubernetes.io/master: ""
-      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
 `)


### PR DESCRIPTION

per recent discussion between @dmage, @adambkaplan, and myself
the image signature controller in OCM is reaching out to the registries like registry.redhat.io and not using the global proxy if set

see https://github.com/openshift/cluster-version-operator/blob/611490ff448962c70ab29a90764a6c30d4ee87dc/lib/resourcebuilder/apps.go#L55

the bug originator manually set the proxy ENVs on the OCM and saw things works

@bparees @mfojtik @soltysh FYI