### PR TITLE
Add component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,3 +15,4 @@ approvers:
   - tnozicka
   - adambkaplan
   - soltysh
+component: openshift-controller-manager


### PR DESCRIPTION
OCM-O is linked to the "openshift-controller-manager" component in bugzilla.