### PR TITLE
WIP Bug 1834852: Add make target to run operator with telepresence 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .vscode/
 _output/
+telepresence.log

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
 	targets/openshift/bindata.mk \
 	targets/openshift/images.mk \
+	targets/openshift/operator/telepresence.mk \
 )
 
 IMAGE_REGISTRY?=registry.svc.ci.openshift.org
@@ -35,3 +36,8 @@ test-e2e: GO_TEST_PACKAGES :=./test/e2e/...
 test-e2e: GO_TEST_FLAGS += -v -count=1
 test-e2e: test-unit
 .PHONY: test-e2e
+
+# Configure the 'telepresence' target
+# See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details
+export TP_DEPLOYMENT_YAML ?=./manifests/09_deployment.yaml
+export TP_CMD_PATH ?=./cmd/cluster-openshift-controller-manager-operator

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -54,12 +54,10 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          defaultMode: 400
           secretName: openshift-controller-manager-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          defaultMode: 440
           name: openshift-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Once telepresence has been installed (see the run-telepresence.sh script for instructions), `make telepresence` will replace the operator's pod with a local process that has access to the same environment as the pod. This can speed up development since iteration doesn't rely on image build/push/pull. See https://telepresence.io for more details.