### PR TITLE
Bug 1852964: account for nil DaemonSet returned from library-go

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -95,9 +95,17 @@ func syncOpenShiftControllerManager_v311_00_to_latest(c OpenShiftControllerManag
 
 	// our configmaps and secrets are in order, now it is time to create the DS
 	// TODO check basic preconditions here
+	var progressingMessages []string
 	actualDaemonSet, _, err := manageOpenShiftControllerManagerDeployment_v311_00_to_latest(c.kubeClient.AppsV1(), c.recorder, operatorConfig, c.targetImagePullSpec, operatorConfig.Status.Generations, forceRollout, c.proxyLister)
 	if err != nil {
-		errors = append(errors, fmt.Errorf("%q: %v", "deployment", err))
+		msg := fmt.Sprintf("%q: %v", "deployment", err)
+		progressingMessages = append(progressingMessages, msg)
+		errors = append(errors, fmt.Errorf(msg))
+	}
+
+	// library-go func called by manageOpenShiftControllerManagerDeployment_v311_00_to_latest can return nil with errors
+	if actualDaemonSet == nil {
+		return syncReturn(c, errors, originalOperatorConfig, operatorConfig)
 	}
 
 	// manage status
@@ -115,7 +123,6 @@ func syncOpenShiftControllerManager_v311_00_to_latest(c OpenShiftControllerManag
 		})
 	}
 
-	var progressingMessages []string
 	if actualDaemonSet.Status.NumberAvailable > 0 && actualDaemonSet.Status.UpdatedNumberScheduled == actualDaemonSet.Status.DesiredNumberScheduled {
 		if len(actualDaemonSet.Annotations[util.VersionAnnotation]) > 0 {
 			operatorConfig.Status.Version = actualDaemonSet.Annotations[util.VersionAnnotation]
@@ -153,6 +160,11 @@ func syncOpenShiftControllerManager_v311_00_to_latest(c OpenShiftControllerManag
 	operatorConfig.Status.ObservedGeneration = operatorConfig.ObjectMeta.Generation
 	resourcemerge.SetDaemonSetGeneration(&operatorConfig.Status.Generations, actualDaemonSet)
 
+	return syncReturn(c, errors, originalOperatorConfig, operatorConfig)
+
+}
+
+func syncReturn(c OpenShiftControllerManagerOperator, errors []error, originalOperatorConfig, operatorConfig *operatorapiv1.OpenShiftControllerManager) (bool, error) {
 	if len(errors) > 0 {
 		message := ""
 		for _, err := range errors {


### PR DESCRIPTION
See https://github.com/openshift/library-go/blob/master/pkg/operator/resource/resourceapply/apps.go#L125

Just going to account for nil rets from library-go in ocm-o

/assign @adambkaplan 