### PR TITLE
Bug 1876858: manifests: rename operator container to be more descriptive

### DIFF
--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       serviceAccountName: openshift-controller-manager-operator
       containers:
-      - name: operator
+      - name: openshift-controller-manager-operator
         image: docker.io/openshift/origin-cluster-openshift-controller-manager-operator:v4.0
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
Rename the operator container to allow for more reasonable debugging.