### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-controller-manager-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -24,6 +25,7 @@ metadata:
   namespace: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -40,6 +42,7 @@ metadata:
   namespace: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/03_config.cr.yaml
+++ b/manifests/03_config.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/04_metricservice.yaml
+++ b/manifests/04_metricservice.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert
     exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:

--- a/manifests/05_builder-deployer-config.yaml
+++ b/manifests/05_builder-deployer-config.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   builderImage: quay.io/openshift/origin-docker-builder:v4.0
   deployerImage: quay.io/openshift/origin-deployer:v4.0

--- a/manifests/06_roles.yaml
+++ b/manifests/06_roles.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/07_serviceaccount.yaml
+++ b/manifests/07_serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: openshift-controller-manager-operator

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: openshift-controller-manager-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1

--- a/manifests/10_flowschema.yaml
+++ b/manifests/10_flowschema.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   distinguisherMethod:
     type: ByUser

--- a/manifests/11_clusteroperator.yaml
+++ b/manifests/11_clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-openshift-controller-manager-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.