### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_01_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -24,6 +25,7 @@ metadata:
   namespace: openshift-controller-manager
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -41,6 +43,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-controller-manager-operator

--- a/manifests/03_config.cr.yaml
+++ b/manifests/03_config.cr.yaml
@@ -6,5 +6,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1

--- a/manifests/04_metricservice.yaml
+++ b/manifests/04_metricservice.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: openshift-controller-manager-operator-serving-cert
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: openshift-controller-manager-operator
   name: metrics

--- a/manifests/05_builder-deployer-config.yaml
+++ b/manifests/05_builder-deployer-config.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   builderImage: quay.io/openshift/origin-docker-builder:v4.0
   deployerImage: quay.io/openshift/origin-deployer:v4.0

--- a/manifests/06_roles.yaml
+++ b/manifests/06_roles.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/07_serviceaccount.yaml
+++ b/manifests/07_serviceaccount.yaml
@@ -6,5 +6,6 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: openshift-controller-manager-operator

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/10_flowschema.yaml
+++ b/manifests/10_flowschema.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   distinguisherMethod:
     type: ByUser

--- a/manifests/11_clusteroperator.yaml
+++ b/manifests/11_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.