### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -19,7 +19,7 @@ spec:
     metadata:
       name: openshift-controller-manager
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager
         controller-manager: "true"

--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -18,6 +18,8 @@ spec:
   template:
     metadata:
       name: openshift-controller-manager
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager
         controller-manager: "true"

--- a/bindata/v3.11.0/openshift-controller-manager/ns.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ns.yaml
@@ -4,5 +4,6 @@ metadata:
   name: openshift-controller-manager
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-controller-manager-operator

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -17,6 +17,8 @@ spec:
   template:
     metadata:
       name: openshift-controller-manager-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager-operator
     spec:

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       name: openshift-controller-manager-operator
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager-operator
     spec:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -197,6 +197,8 @@ spec:
   template:
     metadata:
       name: openshift-controller-manager
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager
         controller-manager: "true"
@@ -508,6 +510,7 @@ metadata:
   name: openshift-controller-manager
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
 `)

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -198,7 +198,7 @@ spec:
     metadata:
       name: openshift-controller-manager
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-controller-manager
         controller-manager: "true"


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>