### PR TITLE
Bug 1948011: seed upgradeable condition in ocm-o cluster operator status so library-go union code can find it

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -161,6 +161,11 @@ func syncOpenShiftControllerManager_v311_00_to_latest(c OpenShiftControllerManag
 		})
 	}
 
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorapiv1.OperatorCondition{
+		Type:   operatorapiv1.OperatorStatusTypeUpgradeable,
+		Status: operatorapiv1.ConditionTrue,
+	})
+
 	operatorConfig.Status.ObservedGeneration = operatorConfig.ObjectMeta.Generation
 	resourcemerge.SetDaemonSetGeneration(&operatorConfig.Status.Generations, actualDaemonSet)
 

--- a/test/framework/conditionhelper.go
+++ b/test/framework/conditionhelper.go
@@ -16,6 +16,7 @@ func hasExpectedClusterOperatorConditions(status *configv1.ClusterOperator) bool
 	gotAvailable := false
 	gotProgressing := false
 	gotDegraded := false
+	gotUpgradeable := false
 	for _, c := range status.Status.Conditions {
 		if c.Type == configv1.OperatorAvailable && c.Status == configv1.ConditionTrue {
 			gotAvailable = true
@@ -26,8 +27,11 @@ func hasExpectedClusterOperatorConditions(status *configv1.ClusterOperator) bool
 		if c.Type == configv1.OperatorDegraded && c.Status == configv1.ConditionFalse {
 			gotDegraded = true
 		}
+		if c.Type == configv1.OperatorUpgradeable && c.Status == configv1.ConditionTrue {
+			gotUpgradeable = true
+		}
 	}
-	return gotAvailable && gotProgressing && gotDegraded
+	return gotAvailable && gotProgressing && gotDegraded && gotUpgradeable
 }
 
 func ensureClusterOperatorStatusIsSet(logger Logger, client *Clientset) error {


### PR DESCRIPTION
/assign @adambkaplan 

ocm-o needs to minimally place the upgradeable condition in its condition array before calling into library-go, otherwise the condition union code at https://github.com/openshift/library-go/blob/d4cedcea81bbe15f5830d07419757597466544e7/pkg/operator/status/condition.go#L32 will skip it and mark it as unknown at https://github.com/openshift/library-go/blob/d4cedcea81bbe15f5830d07419757597466544e7/pkg/operator/status/condition.go#L48

The union code override effectively neuters the code at https://github.com/openshift/library-go/blob/2df205bdd55006a63d3fd22099db73432a0f9bd8/pkg/operator/status/status_controller.go#L195