### PR TITLE
Bug 1925409: Let openshift-controller-manager create service account tokens

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/separate-sa-role.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/separate-sa-role.yaml
@@ -16,6 +16,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -690,6 +690,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
As a part of the rebase to k8s v1.21, the new DynamicClientBuilder needs
permission to create service account tokens. Granting
openshift-controller-manager's "separate-sa" RBAC role permission to
create SA tokens. This role is limited to the "openshift-infra"
namespace, which only contains the service accounts used by
openshift-controller-manager and does not contain any control plane
workloads.