### PR TITLE
Bug 1986829: metrics: use client cert auth for metrics scraping

### DIFF
--- a/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
@@ -21,6 +21,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-controller-manager-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   selector:
     matchLabels:

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -53,6 +53,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: controller-manager.openshift-controller-manager.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
     metricRelabelings:
     - action: drop
       regex: etcd_(debugging|disk|request|server).*


### PR DESCRIPTION
The CMO is now capable of using client cert auth to scrape the metrics endpoints. Use that in our components to reduce API load and allow metrics collection when the API is down - given further authz conditions are met.