### PR TITLE
Bug 2012770: honor labels in openshift-controller-manager metrics

### DIFF
--- a/dependencymagnet/doc.go
+++ b/dependencymagnet/doc.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // dependencymagnet imports code that is not an explicit go dependency, but is used in things

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -47,6 +47,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
     interval: 30s
     port: https
     scheme: https


### PR DESCRIPTION
- in order to not overwrite the namespace in metrics