### PR TITLE
WIP: Clean Up openshift-service-ca Sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 )
 
 replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+
+replace github.com/openshift/library-go => github.com/adambkaplan/library-go v0.0.0-20220119184625-d69dbd21a351

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdko
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RangelReale/osincli v0.0.0-20160924135400-fababb0555f2/go.mod h1:XyjUkMA8GN+tOOPXvnbi3XuRxWFvTJntqvTFnjmhzbk=
+github.com/adambkaplan/library-go v0.0.0-20220119184625-d69dbd21a351 h1:kXAYtbGd9JuiXr3dgnWYXuzRFvNvwBpvpPfnq3/ECg8=
+github.com/adambkaplan/library-go v0.0.0-20220119184625-d69dbd21a351/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/controllercmd/builder.go
@@ -329,7 +329,7 @@ func (b *ControllerBuilder) Run(ctx context.Context, config *unstructured.Unstru
 	leaderConfig := rest.CopyConfig(protoConfig)
 	leaderConfig.Timeout = b.leaderElection.RenewDeadline.Duration
 
-	leaderElection, err := leaderelectionconverter.ToConfigMapLeaderElection(leaderConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
+	leaderElection, err := leaderelectionconverter.ToLeaderElectionWithConfigmapLease(leaderConfig, *b.leaderElection, b.componentName, b.instanceIdentity)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staticresourcecontroller/static_resource_controller.go
@@ -51,10 +51,17 @@ func init() {
 	utilruntime.Must(admissionregistrationv1.AddToScheme(genericScheme))
 }
 
+// StaticResourcesPreconditionsFuncType checks if the precondition is met (is true) and then proceeds with the sync.
+// When the requirement is not met, the controller reports degraded status.
+//
+// In case, the returned ready flag is false, a proper error with a valid description is recommended.
+type StaticResourcesPreconditionsFuncType func(ctx context.Context) (bool, error)
+
 type StaticResourceController struct {
 	name                   string
 	manifests              []conditionalManifests
 	ignoreNotFoundOnCreate bool
+	preconfitions          []StaticResourcesPreconditionsFuncType
 
 	operatorClient v1helpers.OperatorClient
 	clients        *resourceapply.ClientHolder
@@ -99,6 +106,8 @@ func NewStaticResourceController(
 		operatorClient: operatorClient,
 		clients:        clients,
 
+		preconfitions: []StaticResourcesPreconditionsFuncType{defaultStaticResourcesPreconditionsFunc},
+
 		eventRecorder: eventRecorder.WithComponentSuffix(strings.ToLower(name)),
 
 		factory:          factory.New().WithInformers(operatorClient.Informer()).ResyncEvery(1 * time.Minute),
@@ -116,6 +125,18 @@ func NewStaticResourceController(
 // NotFound errors are reported in <name>Degraded condition, but with Degraded=false.
 func (c *StaticResourceController) WithIgnoreNotFoundOnCreate() *StaticResourceController {
 	c.ignoreNotFoundOnCreate = true
+	return c
+}
+
+// WithPrecondition adds a precondition, which blocks the sync method from being executed. Preconditions might be chained using:
+//  WithPrecondition(a).WithPrecondition(b).WithPrecondition(c).
+// If any of the preconditions is false, the sync will result in an error.
+//
+// The requirement parameter should follow the convention described in the StaticResourcesPreconditionsFuncType.
+//
+// When the requirement is not met, the controller reports degraded status.
+func (c *StaticResourceController) WithPrecondition(precondition StaticResourcesPreconditionsFuncType) *StaticResourceController {
+	c.preconfitions = append(c.preconfitions, precondition)
 	return c
 }
 
@@ -262,6 +283,28 @@ func (c *StaticResourceController) Sync(ctx context.Context, syncContext factory
 		return nil
 	}
 
+	for _, precondition := range c.preconfitions {
+		ready, err := precondition(ctx)
+		// We don't care about the other preconditions, we just stop on the first one.
+		if !ready {
+			var message string
+			if err != nil {
+				message = err.Error()
+			} else {
+				message = "the operator didn't specify what preconditions are missing"
+			}
+			if _, _, updateErr := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(operatorv1.OperatorCondition{
+				Type:    fmt.Sprintf("%sDegraded", c.name),
+				Status:  operatorv1.ConditionTrue,
+				Reason:  "PreconditionNotReady",
+				Message: message,
+			})); updateErr != nil {
+				return updateErr
+			}
+			return err
+		}
+	}
+
 	errors := []error{}
 	var notFoundErrorsCount int
 	for _, conditionalManifest := range c.manifests {
@@ -392,4 +435,8 @@ func (c *StaticResourceController) RelatedObjects() ([]configv1.ObjectReference,
 
 func (c *StaticResourceController) Run(ctx context.Context, workers int) {
 	c.factory.WithSync(c.Sync).ToController(c.Name(), c.eventRecorder).Run(ctx, workers)
+}
+
+func defaultStaticResourcesPreconditionsFunc(_ context.Context) (bool, error) {
+	return true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -383,3 +383,42 @@ func InjectObservedProxyIntoContainers(podSpec *corev1.PodSpec, containerNames [
 
 	return nil
 }
+
+func InjectTrustedCAIntoContainers(podSpec *corev1.PodSpec, configMapName string, containerNames []string) error {
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "non-standard-root-system-trust-ca-bundle",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+				Items: []corev1.KeyToPath{
+					{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"},
+				},
+			},
+		},
+	})
+
+	for _, containerName := range containerNames {
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name == containerName {
+				podSpec.InitContainers[i].VolumeMounts = append(podSpec.InitContainers[i].VolumeMounts, corev1.VolumeMount{
+					Name:      "non-standard-root-system-trust-ca-bundle",
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly:  true,
+				})
+			}
+		}
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == containerName {
+				podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, corev1.VolumeMount{
+					Name:      "non-standard-root-system-trust-ca-bundle",
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly:  true,
+				})
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -194,7 +194,7 @@ github.com/openshift/client-go/operator/informers/externalversions/operator/v1
 github.com/openshift/client-go/operator/informers/externalversions/operator/v1alpha1
 github.com/openshift/client-go/operator/listers/operator/v1
 github.com/openshift/client-go/operator/listers/operator/v1alpha1
-# github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492
+# github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492 => github.com/adambkaplan/library-go v0.0.0-20220119184625-d69dbd21a351
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/config/client


### PR DESCRIPTION
Use the new ApplyInjectableConfigMap function to sync the serivce
serving CA ConfigMap. This change also augments the operator e2e test to
verify that we are correctly syncing the service-ca ConfigMap.