### PR TITLE
Bug  2042587: Fix Conflict Error in Operator Tests

### DIFF
--- a/test/e2e/cluster_openshift_controller_manager_operator_test.go
+++ b/test/e2e/cluster_openshift_controller_manager_operator_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -22,16 +23,29 @@ func TestClusterOpenshiftControllerManagerOperator(t *testing.T) {
 }
 
 func TestClusterBuildConfigObservation(t *testing.T) {
+	ctx := context.Background()
 	client := framework.MustNewClientset(t, nil)
 	// make sure the operator is fully up
 	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
-	buildConfig, err := client.Builds().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	// The CVO should be creating these cluster configuration objects on cluster install
+	var buildConfig *configv1.Build
+
+	err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (done bool, err error) {
+		buildConfig, err = client.Builds().Get(ctx, "cluster", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
 	if err != nil {
-		t.Logf("error getting openshift controller manager config: %v", err)
+		t.Fatalf("error getting cluster build config: %v", err)
 	}
 
-	buildDefaults := configv1.BuildDefaults{
+	buildConfig.Spec.BuildDefaults = configv1.BuildDefaults{
 		Env: []corev1.EnvVar{
 			{
 				Name:  "FOO",
@@ -40,37 +54,25 @@ func TestClusterBuildConfigObservation(t *testing.T) {
 		},
 	}
 
-	if buildConfig == nil {
-		buildConfig = &configv1.Build{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "cluster",
-			},
-			Spec: configv1.BuildSpec{
-				BuildDefaults: buildDefaults,
-			},
-		}
-
-		if _, err := client.Builds().Create(context.TODO(), buildConfig, metav1.CreateOptions{}); err != nil {
-			t.Fatalf("could not create cluster build configuration: %v", err)
-		}
-	} else {
-		buildConfig.Spec.BuildDefaults = buildDefaults
-
-		if _, err := client.Builds().Update(context.TODO(), buildConfig, metav1.UpdateOptions{}); err != nil {
-			t.Fatalf("could not create cluster build configuration: %v", err)
-		}
+	if _, err := client.Builds().Update(ctx, buildConfig, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("could not update cluster build configuration: %v", err)
 	}
 
 	defer func() {
-		buildConfig.Spec.BuildDefaults.Env = []corev1.EnvVar{}
-
-		if _, err := client.Builds().Update(context.TODO(), buildConfig, metav1.UpdateOptions{}); err != nil {
+		// Other things may update the cluster build config - get a fresh copy
+		buildConfig, err = client.Builds().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			t.Logf("failed to get cluster build configuration: %v", err)
+			return
+		}
+		buildConfig.Spec.BuildDefaults = configv1.BuildDefaults{}
+		if _, err := client.Builds().Update(ctx, buildConfig, metav1.UpdateOptions{}); err != nil {
 			t.Logf("failed to clean up cluster build config: %v", err)
 		}
 	}()
 
 	err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		cfg, err := client.OpenShiftControllerManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		cfg, err := client.OpenShiftControllerManagers().Get(ctx, "cluster", metav1.GetOptions{})
 		if cfg == nil || err != nil {
 			t.Logf("error getting openshift controller manager config: %v", err)
 			return false, nil
@@ -88,13 +90,17 @@ func TestClusterBuildConfigObservation(t *testing.T) {
 }
 
 func TestClusterImageConfigObservation(t *testing.T) {
+	ctx := context.Background()
 	client := framework.MustNewClientset(t, nil)
 	// make sure the operator is fully up
 	framework.MustEnsureClusterOperatorStatusIsSet(t, client)
 
-	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		cfg, err := client.OpenShiftControllerManagers().Get(context.TODO(), "cluster", metav1.GetOptions{})
-		if cfg == nil || err != nil {
+	err := wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+		cfg, err := client.OpenShiftControllerManagers().Get(ctx, "cluster", metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
 			t.Logf("error getting openshift controller manager config: %v", err)
 			return false, nil
 		}


### PR DESCRIPTION
The operator tests can sometimes flake on teardown due to an object
conflict. This change ensures that the teardown function fetches a
current version of the cluster build config before it resets the object.