### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -22,9 +22,18 @@ spec:
       labels:
         app: openshift-controller-manager-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-controller-manager-operator
       containers:
       - name: openshift-controller-manager-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: docker.io/openshift/origin-cluster-openshift-controller-manager-operator:v4.0
         imagePullPolicy: IfNotPresent
         ports:
@@ -57,12 +66,10 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          defaultMode: 400
           secretName: openshift-controller-manager-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          defaultMode: 440
           name: openshift-controller-manager-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-controller-manager-operator/deployments/openshift-controller-manager-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"openshift-controller-manager-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"openshift-controller-manager-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"openshift-controller-manager-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"openshift-controller-manager-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc @soltysh @stlaz 