### PR TITLE
AUTH-133: bindata: comply to restricted pod security level

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ds.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ds.yaml
@@ -24,10 +24,19 @@ spec:
         app: openshift-controller-manager
         controller-manager: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-node-critical 
       serviceAccountName: openshift-controller-manager-sa
       containers:
       - name: controller-manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
         command: ["openshift-controller-manager", "start"]

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -203,10 +203,19 @@ spec:
         app: openshift-controller-manager
         controller-manager: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: system-node-critical 
       serviceAccountName: openshift-controller-manager-sa
       containers:
       - name: controller-manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
         command: ["openshift-controller-manager", "start"]


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
pods "controller-manager-qg9hz" is forbidden: violates PodSecurity "restricted:latest": runAsNonRoot != true (pod or container "controller-manager" must set securityContext.runAsNonRoot=true)
```

/cc @soltysh @stlaz 