### PR TITLE
Bug 2110629: Set openshift.io/run-level to nil in openshift-controller-manager namespace

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ns.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ns.yaml
@@ -7,3 +7,4 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -522,6 +522,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
 `)
 
 func v3110OpenshiftControllerManagerNsYamlBytes() ([]byte, error) {


### PR DESCRIPTION
The run-level was removed in https://github.com/openshift/cluster-openshift-controller-manager-operator/commit/d12a6ff349028b2d484643f8bf22e1377a2d378a
But because how the cluster-version operator reconciles manifest labels,
 dropping a label from the manifest does not remove it from the in-cluster resource
 when old clusters are updated into the new manifest.
This commit uses the approach the cluster-version operator used to drop its run-level,
 by setting the value to an empty string, which the run-level-consuming code treats identically to an unset label.

This avoids errors about:
```
...container has runAsNonRoot and image will run as root...
```
when updating to 4.11.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>