### PR TITLE
fix ingress-to-route-controller RBAC

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrole.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/ingress-to-route-controller-clusterrole.yaml
@@ -15,7 +15,8 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingress
+  - ingresses
+  - ingressclasses
   verbs:
   - get
   - list
@@ -47,6 +48,7 @@ rules:
   - update
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -362,7 +362,8 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingress
+  - ingresses
+  - ingressclasses
   verbs:
   - get
   - list
@@ -394,6 +395,7 @@ rules:
   - update
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:


### PR DESCRIPTION
found some missing RBAC requirements for  ingress-to-route-controller when implementing https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/255. Till now they were fulfilled by using shared kube informers