### PR TITLE
OCPBUGS-722: Fix NPD when accessing rote controller spec.deployment.replicas

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/route-controller-deploy.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/route-controller-deploy.yaml
@@ -8,6 +8,7 @@ metadata:
     route-controller-manager: "true"
 spec:
   # The number of replicas will be set in code to the number of master nodes.
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -782,6 +782,7 @@ metadata:
     route-controller-manager: "true"
 spec:
   # The number of replicas will be set in code to the number of master nodes.
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
The field is dereferenced in the code when comparing spec against status
which currently can lead to a NPD. Update the yaml manifest with the
default the APIServer would set to avoid that.

Ref https://issues.redhat.com/browse/OCPBUGS-765
Ref https://issues.redhat.com/browse/OCPBUGS-722

/assign @atiratree @deads2k 

Sample of CI failure where this paniced: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_kubernetes/1358/pull-ci-openshift-kubernetes-master-e2e-aws-serial/1564732125813411840/artifacts/e2e-aws-serial/gather-extra/artifacts/pods/openshift-controller-manager-operator_openshift-controller-manager-operator-84b9d797f9-ldfl7_openshift-controller-manager-operator_previous.log 