### PR TITLE
OCPBUGS-765: Check that replicas isn't nil before dereferencing

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -170,7 +170,7 @@ func syncOpenShiftControllerManager_v311_00_to_latest(
 	if actualRCDeployment.Status.AvailableReplicas == 0 {
 		progressingMessages = append(progressingMessages, fmt.Sprintf("deployment/route-controller-manager: available replicas is %d, desired available replicas > %d", actualRCDeployment.Status.AvailableReplicas, 1))
 	}
-	if actualRCDeployment.Status.UpdatedReplicas != *actualRCDeployment.Spec.Replicas {
+	if actualRCDeployment.Spec.Replicas != nil && actualRCDeployment.Status.UpdatedReplicas != *actualRCDeployment.Spec.Replicas {
 		progressingMessages = append(progressingMessages, fmt.Sprintf("deployment/route-controller-manager: updated replicas is %d, desired replicas is %d", actualRCDeployment.Status.UpdatedReplicas, *actualRCDeployment.Spec.Replicas))
 	}
 	if operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration {


### PR DESCRIPTION
We have some examples of this code panicking in CI, we should check that
Replicas is not nill before dereferencing.

...
2022-08-31T03:30:19.676723913Z I0831 03:30:19.676706       1 event.go:285] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-controller-manager-operator", Name:"openshift-controller-manager-operator", UID:"3feb1e53-4f26-4ced-8f9f-f45c7eca94b9", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'DeploymentCreateFailed' Failed to create Deployment.apps/route-controller-manager -n openshift-route-controller-manager: namespaces "openshift-route-controller-manager" not found
2022-08-31T03:30:19.676815245Z E0831 03:30:19.676794       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2022-08-31T03:30:19.676815245Z goroutine 349 [running]:
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1fa3640?, 0x38bd8a0})
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:75 +0x99
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x2695420?})
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:49 +0x75
2022-08-31T03:30:19.676815245Z panic({0x1fa3640, 0x38bd8a0})
2022-08-31T03:30:19.676815245Z     runtime/panic.go:838 +0x207
2022-08-31T03:30:19.676815245Z github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.syncOpenShiftControllerManager_v311_00_to_latest({{0xc00005c006, 0x7f}, {0x26cd280, 0xc000b1ea70}, {0x26a29a8, 0xc000b1eb60}, {0x26d2ec8, 0xc000776780}, {0x2699fc0, 0xc00027b5c0}, ...}, ...)
2022-08-31T03:30:19.676815245Z     github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/sync_openshiftcontrollermanager_v311_00.go:173 +0x2060
2022-08-31T03:30:19.676815245Z github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.OpenShiftControllerManagerOperator.sync({{0xc00005c006, 0x7f}, {0x26cd280, 0xc000b1ea70}, {0x26a29a8, 0xc000b1eb60}, {0x26d2ec8, 0xc000776780}, {0x2699fc0, 0xc00027b5c0}, ...})
2022-08-31T03:30:19.676815245Z     github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:125 +0xbc
2022-08-31T03:30:19.676815245Z github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).processNextWorkItem(0xc00046af30)
2022-08-31T03:30:19.676815245Z     github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:161 +0x158
2022-08-31T03:30:19.676815245Z github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).runWorker(0xc000c5dd40?, {0x0?, 0x2?})
2022-08-31T03:30:19.676815245Z     github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:147 +0x25
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:188 +0x25
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x0?)
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:155 +0x3e
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00066d6c8?, {0x269bba0, 0xc000c5dd40}, 0x1, 0xc00007df20)
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:156 +0xb6
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x93364fe6b7e86e01?, 0x3b9aca00, 0x0, 0x78?, 0x270069a50?)
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:133 +0x89
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x26bf678, 0xc000124340}, 0xc000c74180, 0xc000670120?, 0x0?, 0x0?)
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:188 +0x99
2022-08-31T03:30:19.676815245Z k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x26bf678?, 0xc000124340?}, 0xc00066d768?, 0xc00066d778?)
2022-08-31T03:30:19.676815245Z     k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:99 +0x2b
2022-08-31T03:30:19.676815245Z created by github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).Run
2022-08-31T03:30:19.676815245Z     github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:142 +0x1bd
2022-08-31T03:30:19.676899137Z I0831 03:30:19.676884       1 event.go:285] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-controller-manager-operator", Name:"openshift-controller-manager-operator", UID:"3feb1e53-4f26-4ced-8f9f-f45c7eca94b9", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Warning' reason: 'Openshift-Controller-Manager-OperatorPanic' Panic observed: runtime error: invalid memory address or nil pointer dereference
...