### PR TITLE
OCPBUGS-722: Prevent panic in the operator code, when managing route controller

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -170,8 +170,12 @@ func syncOpenShiftControllerManager_v311_00_to_latest(
 	if actualRCDeployment.Status.AvailableReplicas == 0 {
 		progressingMessages = append(progressingMessages, fmt.Sprintf("deployment/route-controller-manager: available replicas is %d, desired available replicas > %d", actualRCDeployment.Status.AvailableReplicas, 1))
 	}
-	if actualRCDeployment.Status.UpdatedReplicas != *actualRCDeployment.Spec.Replicas {
-		progressingMessages = append(progressingMessages, fmt.Sprintf("deployment/route-controller-manager: updated replicas is %d, desired replicas is %d", actualRCDeployment.Status.UpdatedReplicas, *actualRCDeployment.Spec.Replicas))
+	if actualRCDeployment.Spec.Replicas == nil || actualRCDeployment.Status.UpdatedReplicas != *actualRCDeployment.Spec.Replicas {
+		desiredReplicas := "nil"
+		if actualRCDeployment.Spec.Replicas != nil {
+			desiredReplicas = fmt.Sprintf("%d", *actualRCDeployment.Spec.Replicas)
+		}
+		progressingMessages = append(progressingMessages, fmt.Sprintf("deployment/route-controller-manager: updated replicas is %d, desired replicas is %s", actualRCDeployment.Status.UpdatedReplicas, desiredReplicas))
 	}
 	if operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration {
 		progressingMessages = append(progressingMessages, fmt.Sprintf("openshiftcontrollermanagers.operator.openshift.io/cluster: observed generation is %d, desired generation is %d.", operatorConfig.Status.ObservedGeneration, operatorConfig.ObjectMeta.Generation))


### PR DESCRIPTION
Found panic in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-kube-apiserver-operator/1374/pull-ci-openshift-cluster-kube-apiserver-operator-master-e2e-aws-single-node/1565251027806982144/artifacts/e2e-aws-single-node/gather-extra/artifacts/pods/openshift-controller-manager-operator_openshift-controller-manager-operator-77b7cb944c-cbf7m_openshift-controller-manager-operator_previous.log :
```
E0901 08:45:09.350287       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 658 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1fa3640?, 0x38bd8a0})
	k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:75 +0x99
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x2695420?})
	k8s.io/apimachinery@v0.24.0/pkg/util/runtime/runtime.go:49 +0x75
panic({0x1fa3640, 0x38bd8a0})
	runtime/panic.go:838 +0x207
github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.syncOpenShiftControllerManager_v311_00_to_latest({{0xc00005c006, 0x7f}, {0x26cd280, 0xc000b986b0}, {0x26a29a8, 0xc000b987a0}, {0x26d2ec8, 0xc000cc8300}, {0x2699fc0, 0xc0006e1700}, ...}, ...)
	github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/sync_openshiftcontrollermanager_v311_00.go:173 +0x2060
github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.OpenShiftControllerManagerOperator.sync({{0xc00005c006, 0x7f}, {0x26cd280, 0xc000b986b0}, {0x26a29a8, 0xc000b987a0}, {0x26d2ec8, 0xc000cc8300}, {0x2699fc0, 0xc0006e1700}, ...})
	github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:125 +0xbc
github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).processNextWorkItem(0xc00090b9e0)
	github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:161 +0x158
github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).runWorker(0xc00077c780?, {0x22f7354?, 0x1?})
	github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/operator.go:147 +0x25
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:188 +0x25
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000174780?)
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:155 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x269bba0, 0xc00077c780}, 0x1, 0xc0001ad2c0)
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x1?, 0x3b9aca00, 0x0, 0x0?, 0x1f4?)
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x26bf678, 0xc0002ef900}, 0xc000a947a0, 0xc000b187a0?, 0x9c3466?, 0x0?)
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:188 +0x99
k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x26bf678?, 0xc0002ef900?}, 0xc0006523a0?, 0xc000b187b8?)
	k8s.io/apimachinery@v0.24.0/pkg/util/wait/wait.go:99 +0x2b
created by github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator.(*OpenShiftControllerManagerOperator).Run
```

/assign @atiratree 