### PR TITLE
Revert "switch to route-controller-manager image and use ApplyDeployment"

### DIFF
--- a/bindata/v3.11.0/openshift-controller-manager/route-controller-deploy.yaml
+++ b/bindata/v3.11.0/openshift-controller-manager/route-controller-deploy.yaml
@@ -42,7 +42,7 @@ spec:
             - ALL
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
-        command: [ "route-controller-manager", "start" ]
+        command: [ "openshift-controller-manager", "route-controller-manager-start" ]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         resources:

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -58,8 +58,6 @@ spec:
           value: "0.0.1-snapshot"
         - name: IMAGE
           value: quay.io/openshift/origin-openshift-controller-manager:v4.2
-        - name: ROUTE_CONTROLLER_MANAGER_IMAGE
-          value: quay.io/openshift/origin-openshift-route-controller-manager:v4.12
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -18,7 +18,3 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-deployer:v4.0
-  - name: openshift-route-controller-manager
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-openshift-route-controller-manager:v4.12

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -40,10 +40,9 @@ type nodeCountFunc func(nodeSelector map[string]string) (*int32, error)
 type ensureAtMostOnePodPerNodeFunc func(spec *appsv1.DeploymentSpec, component string) error
 
 type OpenShiftControllerManagerOperator struct {
-	targetImagePullSpec                       string
-	routeControllerManagerTargetImagePullSpec string
-	operatorConfigClient                      operatorclientv1.OperatorV1Interface
-	proxyLister                               proxyvclient1.ProxyLister
+	targetImagePullSpec  string
+	operatorConfigClient operatorclientv1.OperatorV1Interface
+	proxyLister          proxyvclient1.ProxyLister
 
 	kubeClient       kubernetes.Interface
 	configMapsGetter coreclientv1.ConfigMapsGetter
@@ -64,7 +63,6 @@ type OpenShiftControllerManagerOperator struct {
 
 func NewOpenShiftControllerManagerOperator(
 	targetImagePullSpec string,
-	routeControllerManagerTargetImagePullSpec string,
 	operatorConfigInformer operatorinformersv1.OpenShiftControllerManagerInformer,
 	proxyInformer configinformerv1.ProxyInformer,
 	kubeInformers v1helpers.KubeInformersForNamespaces,
@@ -75,17 +73,16 @@ func NewOpenShiftControllerManagerOperator(
 	recorder events.Recorder,
 ) *OpenShiftControllerManagerOperator {
 	c := &OpenShiftControllerManagerOperator{
-		targetImagePullSpec:                       targetImagePullSpec,
-		routeControllerManagerTargetImagePullSpec: routeControllerManagerTargetImagePullSpec,
-		operatorConfigClient:                      operatorConfigClient,
-		countNodes:                                countNodes,
-		ensureAtMostOnePodPerNode:                 ensureAtMostOnePodPerNode,
-		proxyLister:                               proxyInformer.Lister(),
-		kubeClient:                                kubeClient,
-		configMapsGetter:                          v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformers),
-		queue:                                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "OpenshiftControllerManagerOperator"),
-		rateLimiter:                               flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
-		recorder:                                  recorder,
+		targetImagePullSpec:       targetImagePullSpec,
+		operatorConfigClient:      operatorConfigClient,
+		countNodes:                countNodes,
+		ensureAtMostOnePodPerNode: ensureAtMostOnePodPerNode,
+		proxyLister:               proxyInformer.Lister(),
+		kubeClient:                kubeClient,
+		configMapsGetter:          v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformers),
+		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "OpenshiftControllerManagerOperator"),
+		rateLimiter:               flowcontrol.NewTokenBucketRateLimiter(0.05 /*3 per minute*/, 4),
+		recorder:                  recorder,
 	}
 
 	operatorConfigInformer.Informer().AddEventHandler(c.eventHandler())

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -72,7 +72,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	// DaemonSet and associated ConfigMaps.
 	operator := NewOpenShiftControllerManagerOperator(
 		os.Getenv("IMAGE"),
-		os.Getenv("ROUTE_CONTROLLER_MANAGER_IMAGE"),
 		operatorConfigInformers.Operator().V1().OpenShiftControllerManagers(),
 		configInformers.Config().V1().Proxies(),
 		kubeInformers,

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
@@ -6,7 +6,6 @@ import (
 	workloadcontroller "github.com/openshift/library-go/pkg/operator/apiserver/controller/workload"
 	"k8s.io/apimachinery/pkg/runtime"
 	"os"
-	"strconv"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -431,7 +430,6 @@ func TestProgressingCondition(t *testing.T) {
 			objects := []runtime.Object{
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-controller-manager"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
-				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "client-ca", Namespace: "openshift-kube-apiserver"}},
 			}
 			if tc.daemonSet != nil {
 				objects = append(objects, tc.daemonSet)
@@ -541,15 +539,7 @@ func TestDeploymentWithProxy(t *testing.T) {
 		},
 	}
 
-	specAnnotations := map[string]string{
-		"openshiftcontrollermanagers.operator.openshift.io/cluster": strconv.FormatInt(operatorConfig.ObjectMeta.Generation, 10),
-		"configmaps/config":               "54587",
-		"configmaps/client-ca":            "12515",
-		"configmaps/openshift-service-ca": "45789",
-		"configmaps/openshift-global-ca":  "56784",
-	}
-
-	ds, rcBool, err := manageOpenShiftControllerManagerDeployment_v311_00_to_latest(dsClient, recorder, operatorConfig, "my.co/repo/img:latest", operatorConfig.Status.Generations, proxyLister, specAnnotations)
+	ds, rcBool, err := manageOpenShiftControllerManagerDeployment_v311_00_to_latest(dsClient, recorder, operatorConfig, "my.co/repo/img:latest", operatorConfig.Status.Generations, false, proxyLister)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -816,7 +816,7 @@ spec:
             - ALL
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
-        command: [ "route-controller-manager", "start" ]
+        command: [ "openshift-controller-manager", "route-controller-manager-start" ]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
         resources:


### PR DESCRIPTION
Reverts openshift/cluster-openshift-controller-manager-operator#258; tracked by OCPBUGS-1929

Per TRT policy, we are reverting this breaking change to get ci and/or nightly payloads flowing again.  This PR broke nightly payloads as the image was unavailable:

```
operator "cluster-openshift-controller-manager-operator" contained an invalid image-references file: no input image tag named "openshift-route-controller-manager"
```

Please follow https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release-image and work with the ART team to get this image built and available.


CC:  @atiratree, @ingvagabund,  @deads2k 