### PR TITLE
OCPBUGS-13926: change the operator log level to default normal in the deployment

### DIFF
--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -43,7 +43,6 @@ spec:
         command: ["cluster-openshift-controller-manager-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/config.yaml"
-        - "-v=4"
         resources:
           requests:
             memory: 50Mi


### PR DESCRIPTION
[issue 290](https://github.com/openshift/cluster-openshift-controller-manager-operator/issues/290)