### PR TITLE
OCPBUGS-18498: Disable BuildConfigChange controller when Build cap is disabled

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -39,8 +39,9 @@ import (
 // ControllerCapabilities maps controllers to capabilities, so we can enable/disable controllers
 // based on capabilities.
 var controllerCapabilities = map[controlplanev1.OpenShiftControllerName]configv1.ClusterVersionCapability{
-	controlplanev1.OpenshiftBuildController:            configv1.ClusterVersionCapabilityBuild,
-	controlplanev1.OpenshiftDeploymentConfigController: configv1.ClusterVersionCapabilityDeploymentConfig,
+	controlplanev1.OpenshiftBuildController:             configv1.ClusterVersionCapabilityBuild,
+	controlplanev1.OpenshiftDeploymentConfigController:  configv1.ClusterVersionCapabilityDeploymentConfig,
+	controlplanev1.OpenshiftBuildConfigChangeController: configv1.ClusterVersionCapabilityBuild,
 }
 
 // syncOpenShiftControllerManager_v311_00_to_latest takes care of synchronizing (not upgrading) the thing we're managing.

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
@@ -62,7 +62,7 @@ func TestExpectedConfigMap(t *testing.T) {
 			APIVersion: "openshiftcontrolplane.config.openshift.io/v1",
 			Kind:       "OpenShiftControllerManagerConfig",
 		},
-		Controllers:        []string{"*", "-openshift.io/build"},
+		Controllers:        []string{"*", "-openshift.io/build", "-openshift.io/build-config-change"},
 		ServiceServingCert: openshiftcontrolplanev1.ServiceServingCert{},
 	}
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
@@ -137,7 +137,7 @@ func TestConfigMapControllerDisabling(t *testing.T) {
 				configv1.ClusterVersionCapabilityDeploymentConfig,
 			},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
-			result:              map[string][]string{"controllers": {"*", "-openshift.io/build", "-openshift.io/deploymentconfig"}},
+			result:              map[string][]string{"controllers": {"*", "-openshift.io/build", "-openshift.io/build-config-change", "-openshift.io/deploymentconfig"}},
 		},
 		{
 			name:                "ControllersDisabledButUnknown",


### PR DESCRIPTION
With this https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/291, we have an ability to disable controllers if the capability they are belonging to is disabled. 

But BuildConfigChange controller also belongs to Build capability and this PR adds it to the capability list. If Build cap
is disabled, openshift-controller-manager should not run BuildConfigChange controller.