### PR TITLE
OCPBUGS-18932: Always sort disabled controller list

### DIFF
--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -308,6 +309,9 @@ func disableControllers(clusterVersion *configv1.ClusterVersion) []string {
 			controllers = append(controllers, fmt.Sprintf("-%s", cont))
 		}
 	}
+	// we need to sort this slice to have always same list
+	// otherwise, change in the order would modify configmap and causes roll out
+	sort.Strings(controllers)
 	return controllers
 }
 


### PR DESCRIPTION
Currently, controller list is unsorted and any order change in that list (even though the values are not changed) causes new OCM roll out.

This is happening only when the capabitilies are disabled because if there is no disabled capability, controller list has only 1 item.

This commit always sorts this list for consistency and prevent unnecessary rollouts.