### PR TITLE
Revert "Revert #300 "API-1666: add image pull secret cleanup controller""

### DIFF
--- a/pkg/operator/configobservation/controllers/capability_imageregistry.go
+++ b/pkg/operator/configobservation/controllers/capability_imageregistry.go
@@ -1,49 +1,20 @@
 package controllers
 
 import (
-	"fmt"
-
-	configv1 "github.com/openshift/api/config/v1"
 	openshiftcontrolplanev1 "github.com/openshift/api/openshiftcontrolplane/v1"
 	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/configobservation"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
+	"github.com/openshift/cluster-openshift-controller-manager-operator/pkg/operator/internalimageregistry"
 )
 
 func disabledImageRegistryControllers(listers configobservation.Listers) ([]openshiftcontrolplanev1.OpenShiftControllerName, error) {
-	cv, err := listers.ClusterVersionLister.Get("version")
+	enabled, err := internalimageregistry.ImageRegistryIsEnabled(listers.ClusterVersionLister, listers.ClusterOperatorLister)
 	if err != nil {
 		return nil, err
 	}
-	var imageRegistryCapabilityEnabled bool
-	for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
-		if capability == configv1.ClusterVersionCapabilityImageRegistry {
-			imageRegistryCapabilityEnabled = true
-			break
-		}
-	}
-	controllers := []openshiftcontrolplanev1.OpenShiftControllerName{
-		openshiftcontrolplanev1.OpenShiftServiceAccountPullSecretsController,
-	}
-	if !imageRegistryCapabilityEnabled {
-		return controllers, nil
-	}
-
-	co, err := listers.ClusterOperatorLister.Get("image-registry")
-	if err != nil && !errors.IsNotFound(err) {
-		return nil, fmt.Errorf("unable to retrieve clusteroperators.config.openshift.io/image-registry: %w", err)
-	}
-	if errors.IsNotFound(err) {
-		klog.V(4).Infof("clusteroperators.config.openshift.io/image-registry does not exist yet.")
-		return controllers, nil
-	}
-
-	// Check if internal image registry is "Removed". Any condition should do.
-	if len(co.Status.Conditions) == 0 {
-		return nil, fmt.Errorf("clusteroperators.config.openshift.io/image-registry conditions do not yet exist")
-	}
-	if co.Status.Conditions[0].Reason == "Removed" {
-		return controllers, nil
+	if !enabled {
+		return []openshiftcontrolplanev1.OpenShiftControllerName{
+			openshiftcontrolplanev1.OpenShiftServiceAccountPullSecretsController,
+		}, nil
 	}
 	// ImageRegistry capability is enabled, and internal image registry is enabled, nothing to disable.
 	return nil, nil

--- a/pkg/operator/configobservation/controllers/observe_controllers_test.go
+++ b/pkg/operator/configobservation/controllers/observe_controllers_test.go
@@ -83,13 +83,13 @@ func TestObserveControllers(t *testing.T) {
 		{
 			name:           "NoClusterOperator",
 			clusterVersion: clusterVersion(withImageRegistryCapability, withBuildCapability, withDeploymentConfigCapability),
-			expectedConfig: defaultConfig(withDisabled("openshift.io/serviceaccount-pull-secrets")),
+			expectedConfig: defaultConfig(),
 		},
 		{
 			name:            "RegistryRemoved",
 			clusterVersion:  clusterVersion(withImageRegistryCapability, withBuildCapability, withDeploymentConfigCapability),
 			clusterOperator: clusterOperator("Removed"),
-			expectedConfig:  defaultConfig(withDisabled("openshift.io/serviceaccount-pull-secrets")),
+			expectedConfig:  defaultConfig(withDisabled(openshiftcontrolplanev1.OpenShiftServiceAccountPullSecretsController)),
 		},
 		{
 			name:            "RegistryNotRemoved",
@@ -100,13 +100,13 @@ func TestObserveControllers(t *testing.T) {
 		{
 			name:           "NoImageRegistryCapabilityNoRegistryConfig",
 			clusterVersion: clusterVersion(withBuildCapability, withDeploymentConfigCapability),
-			expectedConfig: defaultConfig(withDisabled("openshift.io/serviceaccount-pull-secrets")),
+			expectedConfig: defaultConfig(withDisabled(openshiftcontrolplanev1.OpenShiftServiceAccountPullSecretsController)),
 		},
 		{
 			name:            "NoImageRegistryCapabilityRegistryRemoved",
 			clusterVersion:  clusterVersion(withBuildCapability, withDeploymentConfigCapability),
 			clusterOperator: clusterOperator("Removed"),
-			expectedConfig:  defaultConfig(withDisabled("openshift.io/serviceaccount-pull-secrets")),
+			expectedConfig:  defaultConfig(withDisabled(openshiftcontrolplanev1.OpenShiftServiceAccountPullSecretsController)),
 		},
 		{
 			name:            "NoImageRegistryCapabilityRegistryNotRemoved",

--- a/pkg/operator/internalimageregistry/cleanup_controller.go
+++ b/pkg/operator/internalimageregistry/cleanup_controller.go
@@ -1,0 +1,180 @@
+package internalimageregistry
+
+import (
+	"context"
+	errs "errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openshift/client-go/config/informers/externalversions"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/build/naming"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type imagePullSecretCleanupController struct {
+	factory.Controller
+	kubeClient            *kubernetes.Clientset
+	serviceAccountLister  corelistersv1.ServiceAccountLister
+	secretLister          corelistersv1.SecretLister
+	clusterVersionLister  configlistersv1.ClusterVersionLister
+	clusterOperatorLister configlistersv1.ClusterOperatorLister
+}
+
+func NewImagePullSecretCleanupController(kubeClient *kubernetes.Clientset, informers v1helpers.KubeInformersForNamespaces, configInformers externalversions.SharedInformerFactory, recorder events.Recorder) *imagePullSecretCleanupController {
+	c := &imagePullSecretCleanupController{
+		kubeClient:            kubeClient,
+		serviceAccountLister:  informers.InformersFor(metav1.NamespaceAll).Core().V1().ServiceAccounts().Lister(),
+		secretLister:          informers.InformersFor("").Core().V1().Secrets().Lister(),
+		clusterVersionLister:  configInformers.Config().V1().ClusterVersions().Lister(),
+		clusterOperatorLister: configInformers.Config().V1().ClusterOperators().Lister(),
+	}
+	c.Controller = factory.New().
+		WithInformers(
+			informers.InformersFor(metav1.NamespaceAll).Core().V1().ServiceAccounts().Informer(),
+			informers.InformersFor("").Core().V1().Secrets().Informer(),
+			configInformers.Config().V1().ClusterVersions().Informer(),
+			configInformers.Config().V1().ClusterOperators().Informer(),
+		).
+		WithSync(c.sync).
+		ToController("ImagePullSecretCleanupController", recorder.WithComponentSuffix("image-pull-secret-cleanup-controller"))
+	return c
+}
+
+func (c *imagePullSecretCleanupController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	imageRegistryEnabled, err := ImageRegistryIsEnabled(c.clusterVersionLister, c.clusterOperatorLister)
+	if err != nil {
+		return err
+	}
+	if !imageRegistryEnabled {
+		return c.cleanup(ctx)
+	}
+	return nil
+}
+
+func (c *imagePullSecretCleanupController) cleanup(ctx context.Context) error {
+	// cleanup service accounts
+	serviceAccounts, err := c.serviceAccountLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("unable to list ServiceAccounts: %w", err)
+	}
+	for _, serviceAccount := range serviceAccounts {
+		imagePullSecretName, imagePullSecret, err := c.imagePullSecretForServiceAccount(serviceAccount)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve the image pull secret for the service account %q (ns=%q): %w", serviceAccount.Name, serviceAccount.Namespace, err)
+		}
+		var tokenSecret *corev1.Secret
+		if imagePullSecret != nil {
+			tokenSecret, err = c.tokenSecretForImagePullSecret(imagePullSecret)
+			if err != nil {
+				return fmt.Errorf("unable to retrive the service account token secret for the image pull secret %q (ns=%q): %w", imagePullSecret.Name, imagePullSecret.Namespace, err)
+			}
+		}
+		if tokenSecret != nil {
+			err := c.kubeClient.CoreV1().Secrets(tokenSecret.Namespace).Delete(ctx, tokenSecret.Name, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("unable to delete the service account token secret %q (ns=%q): %w", tokenSecret.Name, tokenSecret.Namespace, err)
+			}
+		}
+		if imagePullSecret != nil {
+			err := c.kubeClient.CoreV1().Secrets(imagePullSecret.Namespace).Delete(ctx, imagePullSecret.Name, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return fmt.Errorf("unable to delete image pull secret %q (ns=%q): %w", imagePullSecret.Name, imagePullSecret.Namespace, err)
+			}
+		}
+		if len(imagePullSecretName) != 0 {
+			var secretRefs []corev1.ObjectReference
+			for _, secretRef := range serviceAccount.Secrets {
+
+				if secretRef.Name != imagePullSecretName {
+					secretRefs = append(secretRefs, secretRef)
+				}
+			}
+			serviceAccount.Secrets = secretRefs
+
+			var imagePullSecretRefs []corev1.LocalObjectReference = []corev1.LocalObjectReference{}
+			for _, imagePullSecretRef := range serviceAccount.ImagePullSecrets {
+				if imagePullSecretRef.Name != imagePullSecretName {
+					imagePullSecretRefs = append(imagePullSecretRefs, imagePullSecretRef)
+				}
+			}
+			serviceAccount.ImagePullSecrets = imagePullSecretRefs
+			_, err := c.kubeClient.CoreV1().ServiceAccounts(serviceAccount.Namespace).Update(ctx, serviceAccount, metav1.UpdateOptions{})
+			if err != nil {
+				var statusErr *errors.StatusError
+				if errs.As(err, &statusErr) && statusErr.Status().Code == http.StatusConflict {
+					return factory.SyntheticRequeueError
+				}
+				return fmt.Errorf("unable to clean up references to the image pull secret %q (ns=%q) from the service accout %q: %w", imagePullSecret.Name, imagePullSecret.Namespace, serviceAccount.Name, err)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+	return nil
+}
+
+func (c *imagePullSecretCleanupController) imagePullSecretForServiceAccount(serviceAccount *corev1.ServiceAccount) (string, *corev1.Secret, error) {
+	var imagePullSecretName string
+	imagePullSecretNamePrefix := naming.GetName(serviceAccount.Name, "dockercfg-", 58)
+	for _, imagePullSecretRef := range serviceAccount.ImagePullSecrets {
+		if strings.HasPrefix(imagePullSecretRef.Name, imagePullSecretNamePrefix) {
+			imagePullSecretName = imagePullSecretRef.Name
+			break
+		}
+	}
+	if len(imagePullSecretName) == 0 {
+		for _, secretRef := range serviceAccount.Secrets {
+			if strings.HasPrefix(secretRef.Name, imagePullSecretNamePrefix) {
+				imagePullSecretName = secretRef.Name
+				break
+			}
+		}
+	}
+	if len(imagePullSecretName) == 0 {
+		return "", nil, nil
+	}
+	imagePullSecret, err := c.secretLister.Secrets(serviceAccount.Namespace).Get(imagePullSecretName)
+	if errors.IsNotFound(err) {
+		klog.V(2).InfoS("Referenced imagePullSecret does not exist.", "ns", serviceAccount.Namespace, "sa", serviceAccount.Name, "imagePullSecret", imagePullSecretName)
+		return imagePullSecretName, nil, nil
+	}
+	if err != nil {
+		return "", nil, err
+	}
+	// more confirmation that this was generated by ocm
+	if _, ok := imagePullSecret.Annotations["openshift.io/token-secret.name"]; !ok {
+		return "", nil, nil
+	}
+	return imagePullSecretName, imagePullSecret, nil
+}
+
+func (c *imagePullSecretCleanupController) tokenSecretForImagePullSecret(secret *corev1.Secret) (*corev1.Secret, error) {
+	tokenSecretName := secret.Annotations["openshift.io/token-secret.name"]
+	if len(tokenSecretName) == 0 {
+		return nil, nil
+	}
+	tokenSecret, err := c.secretLister.Secrets(secret.Namespace).Get(tokenSecretName)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	}
+	// more confirmation that this was generated by ocm
+	value, ok := tokenSecret.Annotations["kubernetes.io/created-by"]
+	if !ok || value != "openshift.io/create-dockercfg-secrets" {
+		return nil, nil
+	}
+	return tokenSecret, err
+}

--- a/pkg/operator/internalimageregistry/management_state.go
+++ b/pkg/operator/internalimageregistry/management_state.go
@@ -1,0 +1,46 @@
+package internalimageregistry
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+func ImageRegistryIsEnabled(clusterVersionLister configlistersv1.ClusterVersionLister, clusterOperatorLister configlistersv1.ClusterOperatorLister) (bool, error) {
+	cv, err := clusterVersionLister.Get("version")
+	if err != nil {
+		return false, err
+	}
+	var imageRegistryCapabilityEnabled bool
+	for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
+		if capability == configv1.ClusterVersionCapabilityImageRegistry {
+			imageRegistryCapabilityEnabled = true
+			break
+		}
+	}
+	if !imageRegistryCapabilityEnabled {
+		return false, nil
+	}
+
+	co, err := clusterOperatorLister.Get("image-registry")
+	if err != nil && !errors.IsNotFound(err) {
+		return false, fmt.Errorf("unable to retrieve clusteroperators.config.openshift.io/image-registry: %w", err)
+	}
+	if errors.IsNotFound(err) {
+		klog.V(4).Infof("clusteroperators.config.openshift.io/image-registry does not exist yet.")
+		return false, nil
+	}
+
+	// Check if internal image registry is "Removed". Any condition should do.
+	if len(co.Status.Conditions) == 0 {
+		return false, fmt.Errorf("clusteroperators.config.openshift.io/image-registry conditions do not yet exist")
+	}
+	if co.Status.Conditions[0].Reason == "Removed" {
+		return false, nil
+	}
+	// ImageRegistry capability is enabled, and internal image registry is enabled, nothing to disable.
+	return true, nil
+}

--- a/pkg/operator/internalimageregistry/management_state.go
+++ b/pkg/operator/internalimageregistry/management_state.go
@@ -1,14 +1,14 @@
 package internalimageregistry
 
 import (
-	"fmt"
-
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 )
 
+// ImageRegistryIsEnabled returns true if the ImageRegistry capability
+// is enabled and the internal image registry has not been disabled.
 func ImageRegistryIsEnabled(clusterVersionLister configlistersv1.ClusterVersionLister, clusterOperatorLister configlistersv1.ClusterOperatorLister) (bool, error) {
 	cv, err := clusterVersionLister.Get("version")
 	if err != nil {
@@ -25,22 +25,27 @@ func ImageRegistryIsEnabled(clusterVersionLister configlistersv1.ClusterVersionL
 		return false, nil
 	}
 
+	// Given that the capability is enabled, assume the internal image registry is
+	// enabled unless we can explicitly determine otherwise in via the management status.
+
 	co, err := clusterOperatorLister.Get("image-registry")
 	if err != nil && !errors.IsNotFound(err) {
-		return false, fmt.Errorf("unable to retrieve clusteroperators.config.openshift.io/image-registry: %w", err)
+		klog.V(4).ErrorS(err, "unable to retrieve clusteroperators.config.openshift.io/image-registry")
+		return true, nil
 	}
 	if errors.IsNotFound(err) {
-		klog.V(4).Infof("clusteroperators.config.openshift.io/image-registry does not exist yet.")
-		return false, nil
+		klog.V(4).InfoS("clusteroperators.config.openshift.io/image-registry does not exist yet.")
+		return true, nil
 	}
 
 	// Check if internal image registry is "Removed". Any condition should do.
 	if len(co.Status.Conditions) == 0 {
-		return false, fmt.Errorf("clusteroperators.config.openshift.io/image-registry conditions do not yet exist")
+		klog.V(4).InfoS("clusteroperators.config.openshift.io/image-registry conditions do not yet exist")
+		return true, nil
 	}
 	if co.Status.Conditions[0].Reason == "Removed" {
 		return false, nil
 	}
-	// ImageRegistry capability is enabled, and internal image registry is enabled, nothing to disable.
+
 	return true, nil
 }

--- a/vendor/github.com/openshift/library-go/pkg/build/naming/namer.go
+++ b/vendor/github.com/openshift/library-go/pkg/build/naming/namer.go
@@ -1,0 +1,73 @@
+package naming
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	kvalidation "k8s.io/apimachinery/pkg/util/validation"
+)
+
+// GetName returns a name given a base ("deployment-5") and a suffix ("deploy")
+// It will first attempt to join them with a dash. If the resulting name is longer
+// than maxLength: if the suffix is too long, it will truncate the base name and add
+// an 8-character hash of the [base]-[suffix] string.  If the suffix is not too long,
+// it will truncate the base, add the hash of the base and return [base]-[hash]-[suffix]
+func GetName(base, suffix string, maxLength int) string {
+	if maxLength <= 0 {
+		return ""
+	}
+	name := fmt.Sprintf("%s-%s", base, suffix)
+	if len(name) <= maxLength {
+		return name
+	}
+
+	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
+
+	// if the suffix is too long, ignore it
+	if baseLength <= 0 {
+		prefix := base[0:min(len(base), max(0, maxLength-9))]
+		// Calculate hash on initial base-suffix string
+		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))
+		return shortName[:min(maxLength, len(shortName))]
+	}
+
+	prefix := base[0:baseLength]
+	// Calculate hash on initial base-suffix string
+	return fmt.Sprintf("%s-%s-%s", prefix, hash(base), suffix)
+}
+
+// GetPodName calls GetName with the length restriction for pods
+func GetPodName(base, suffix string) string {
+	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// GetConfigMapName calls GetName with the length restriction for ConfigMaps
+func GetConfigMapName(base, suffix string) string {
+	return GetName(base, suffix, kvalidation.DNS1123SubdomainMaxLength)
+}
+
+// max returns the greater of its 2 inputs
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// min returns the lesser of its 2 inputs
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+// hash calculates the hexadecimal representation (8-chars)
+// of the hash of the passed in string using the FNV-a algorithm
+func hash(s string) string {
+	hash := fnv.New32a()
+	hash.Write([]byte(s))
+	intHash := hash.Sum32()
+	result := fmt.Sprintf("%08x", intHash)
+	return result
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,6 +279,7 @@ github.com/openshift/client-go/operator/listers/operator/v1alpha1
 github.com/openshift/library-go/pkg/apps/deployment
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
+github.com/openshift/library-go/pkg/build/naming
 github.com/openshift/library-go/pkg/config/client
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/config/clusterstatus


### PR DESCRIPTION
This reverts commit f45b3c501fcb9923814d5da0558bf31d1b86a15e, reversing
changes made to a84c9d47762575588e4cbf3ec557f137a6b7ca8f.

The failed tests were all 'pathological event' type tests due to existing pods using the deleted image pull secrets. The deleted image pull secrets do not really cause a problem, since they are not used again, but the kubelet emits the events as a warning. Something in this payload if disabling the internal image registry in the middle of the run. 
I have updated the PR to:
* Assumes the image registry is enabled unless explicitly reads the needed config for disablement (what I initially thought was the fix. It is not, but i think it is still good to have).
* Does not delete any image pull secrets (or the corresponding long-lived token) if the image pull secret is being referenced in a pod.