### PR TITLE
[release-4.14] OCPBUGS-23490: Remove blockage of ConfigObserver by build informer has synced flag

### DIFF
--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -29,28 +29,30 @@ func NewConfigObserver(
 	kubeInformersForOperatorNamespace kubeinformers.SharedInformerFactory,
 	featureGateAccessor featuregates.FeatureGateAccess,
 	eventRecorder events.Recorder,
+	buildEnabled bool,
 ) factory.Controller {
-	c := configobserver.NewConfigObserver(
-		operatorClient,
-		eventRecorder,
-		configobservation.Listers{
-			ImageConfigLister:  configInformers.Config().V1().Images().Lister(),
-			BuildConfigLister:  configInformers.Config().V1().Builds().Lister(),
-			NetworkLister:      configInformers.Config().V1().Networks().Lister(),
-			FeatureGateLister_: configInformers.Config().V1().FeatureGates().Lister(),
-			ConfigMapLister:    kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Lister(),
-			PreRunCachesSynced: []cache.InformerSynced{
-				configInformers.Config().V1().Builds().Informer().HasSynced,
-				configInformers.Config().V1().Images().Informer().HasSynced,
-				configInformers.Config().V1().Networks().Informer().HasSynced,
-				kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
-				operatorConfigInformers.Operator().V1().OpenShiftControllerManagers().Informer().HasSynced,
-			},
-		},
-		[]factory.Informer{operatorConfigInformers.Operator().V1().OpenShiftControllerManagers().Informer()},
+	informersSynced := []cache.InformerSynced{
+		configInformers.Config().V1().Images().Informer().HasSynced,
+		configInformers.Config().V1().Networks().Informer().HasSynced,
+		kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Informer().HasSynced,
+		operatorConfigInformers.Operator().V1().OpenShiftControllerManagers().Informer().HasSynced,
+	}
+
+	if buildEnabled {
+		informersSynced = append(informersSynced, configInformers.Config().V1().Builds().Informer().HasSynced)
+	}
+
+	configObservationListers := configobservation.Listers{
+		ImageConfigLister:  configInformers.Config().V1().Images().Lister(),
+		NetworkLister:      configInformers.Config().V1().Networks().Lister(),
+		FeatureGateLister_: configInformers.Config().V1().FeatureGates().Lister(),
+		ConfigMapLister:    kubeInformersForOperatorNamespace.Core().V1().ConfigMaps().Lister(),
+		PreRunCachesSynced: informersSynced,
+	}
+
+	observerFuncs := []configobserver.ObserveConfigFunc{
 		images.ObserveInternalRegistryHostname,
 		images.ObserveExternalRegistryHostnames,
-		builds.ObserveBuildControllerConfig,
 		network.ObserveExternalIPAutoAssignCIDRs,
 		deployimages.ObserveControllerManagerImagesConfig,
 		featuregates.NewObserveFeatureFlagsFunc(
@@ -59,6 +61,19 @@ func NewConfigObserver(
 			[]string{"featureGates"},
 			featureGateAccessor,
 		),
+	}
+
+	if buildEnabled {
+		configObservationListers.BuildConfigLister = configInformers.Config().V1().Builds().Lister()
+		observerFuncs = append(observerFuncs, builds.ObserveBuildControllerConfig)
+	}
+
+	c := configobserver.NewConfigObserver(
+		operatorClient,
+		eventRecorder,
+		configObservationListers,
+		[]factory.Informer{operatorConfigInformers.Operator().V1().OpenShiftControllerManagers().Informer()},
+		observerFuncs...,
 	)
 
 	return c

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -127,6 +128,24 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		controllerConfig.EventRecorder,
 	)
 
+	if !cache.WaitForCacheSync(ctx.Done(), configInformers.Config().V1().ClusterVersions().Informer().HasSynced) {
+		klog.Errorf("timed out waiting for configInformers ClusterVersions")
+		return fmt.Errorf("timed out waiting for configInformers ClusterVersions")
+	}
+
+	buildCapabilityEnabled := false
+	cv, err := configInformers.Config().V1().ClusterVersions().Lister().Get("version")
+	if err != nil {
+		return err
+	}
+
+	for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
+		if capability == configv1.ClusterVersionCapabilityBuild {
+			buildCapabilityEnabled = true
+			break
+		}
+	}
+
 	// ConfigObserver observes the configuration state from cluster config objects and transforms
 	// them into configuration used by openshift-controller-manager
 	configObserver := configobservationcontroller.NewConfigObserver(
@@ -136,6 +155,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		kubeInformers.InformersFor(util.OperatorNamespace),
 		featureGateAccessor,
 		controllerConfig.EventRecorder,
+		buildCapabilityEnabled,
 	)
 
 	// userCAObserver watches the cluster proxy config and updates the resourceSyncer.
@@ -249,8 +269,39 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	go clusterOperatorStatus.Run(ctx, 1)
 	go logLevelController.Run(ctx, 1)
 
-	<-ctx.Done()
-	return fmt.Errorf("stopped")
+	capabilityChangedCh := make(chan struct{})
+	if !buildCapabilityEnabled {
+		// check capability periodically and close chan and return
+		go func() {
+			ticker := time.NewTicker(5 * time.Minute)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ticker.C:
+					cv, err := configInformers.Config().V1().ClusterVersions().Lister().Get("version")
+					if err != nil {
+						klog.Errorf("capability checker error %v", err)
+						continue
+					}
+
+					for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
+						if capability == configv1.ClusterVersionCapabilityBuild {
+							close(capabilityChangedCh)
+							return
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	select {
+	case <-capabilityChangedCh:
+		return fmt.Errorf("capability is enabled, stopping")
+	case <-ctx.Done():
+		return fmt.Errorf("stopped")
+	}
 }
 
 type versionGetter struct {


### PR DESCRIPTION
This is manual cherry-pick of https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/315