### PR TITLE
OCPBUGS-24190: Disable deployer-controller when deploymentconfig is disabled

### DIFF
--- a/pkg/operator/configobservation/controllers/capability_deploymentconfigs.go
+++ b/pkg/operator/configobservation/controllers/capability_deploymentconfigs.go
@@ -24,6 +24,7 @@ func disabledDeploymentConfigControllers(listers configobservation.Listers) ([]o
 	return []openshiftcontrolplanev1.OpenShiftControllerName{
 		openshiftcontrolplanev1.OpenShiftDeploymentConfigController,
 		openshiftcontrolplanev1.OpenShiftDeployerServiceAccountController,
+		openshiftcontrolplanev1.OpenShiftDeployerController,
 	}, nil
 
 }

--- a/pkg/operator/configobservation/controllers/observe_controllers_test.go
+++ b/pkg/operator/configobservation/controllers/observe_controllers_test.go
@@ -131,6 +131,7 @@ func TestObserveControllers(t *testing.T) {
 			expectedConfig: defaultConfig(
 				withDisabled(openshiftcontrolplanev1.OpenShiftDeploymentConfigController),
 				withDisabled(openshiftcontrolplanev1.OpenShiftDeployerServiceAccountController),
+				withDisabled(openshiftcontrolplanev1.OpenShiftDeployerController),
 			),
 		},
 		{
@@ -143,6 +144,7 @@ func TestObserveControllers(t *testing.T) {
 				withDisabled(openshiftcontrolplanev1.OpenShiftBuildConfigChangeController),
 				withDisabled(openshiftcontrolplanev1.OpenShiftBuilderServiceAccountController),
 				withDisabled(openshiftcontrolplanev1.OpenShiftDeployerServiceAccountController),
+				withDisabled(openshiftcontrolplanev1.OpenShiftDeployerController),
 			),
 		},
 	}


### PR DESCRIPTION
There is a deployer-controller in openshift-controller-manager that basically watches
the replicasets and pods and takes action only for the ones created by deploymentconfig.

But when deploymentconfig is disabled, this controller has no meaning. This doesn't create 
any issue because it innocently watches replicasets and pods and since there is no resource
created by deploymentconfig, it just watches forever without taking any action. 

On the other hand, there is no reason running this controller, when deploymenconfig capability
is disabled. That's why, this PR does this.