### PR TITLE
OCPBUGS-29159: no need to rollout operand when we just update operatorCr.operatorloglevel

### DIFF
--- a/pkg/operator/generic_client.go
+++ b/pkg/operator/generic_client.go
@@ -64,7 +64,7 @@ func (p *genericClient) UpdateOperatorSpec(ctx context.Context, resourceVersion 
 	resourceCopy.ResourceVersion = resourceVersion
 	resourceCopy.Spec.OperatorSpec = *spec
 
-	ret, err := p.client.OpenShiftControllerManagers().Update(context.TODO(), resourceCopy, metav1.UpdateOptions{})
+	ret, err := p.client.OpenShiftControllerManagers().Update(ctx, resourceCopy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -80,7 +80,7 @@ func (p *genericClient) UpdateOperatorStatus(ctx context.Context, resourceVersio
 	resourceCopy.ResourceVersion = resourceVersion
 	resourceCopy.Status.OperatorStatus = *status
 
-	ret, err := p.client.OpenShiftControllerManagers().UpdateStatus(context.TODO(), resourceCopy, metav1.UpdateOptions{})
+	ret, err := p.client.OpenShiftControllerManagers().UpdateStatus(ctx, resourceCopy, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/openshift/cluster-openshift-controller-manager-operator/bindata"

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -60,13 +60,9 @@ func syncOpenShiftControllerManager_v311_00_to_latest(
 	operandName := "openshift-controller-manager"
 	rcOperandName := "route-controller-manager"
 
-	specAnnotations := map[string]string{
-		"openshiftcontrollermanagers.operator.openshift.io/cluster": strconv.FormatInt(operatorConfig.ObjectMeta.Generation, 10),
-	}
+	specAnnotations := map[string]string{}
 
-	rcSpecAnnotations := map[string]string{
-		"openshiftcontrollermanagers.operator.openshift.io/cluster": strconv.FormatInt(operatorConfig.ObjectMeta.Generation, 10),
-	}
+	rcSpecAnnotations := map[string]string{}
 
 	// OpenShift Controller Manager
 	configMap, _, err := manageOpenShiftControllerManagerConfigMap_v311_00_to_latest(c.clusterVersionLister, c.kubeClient, c.configMapsGetter, c.recorder, operatorConfig)


### PR DESCRIPTION
1. when only updating the operatorConfig.operatorloglevel, the operatorConfig.ObjectMeta.Generation will change(and this will lead to the operand specAnnotations changed as well ), but this time we should not rollout the operand.
2. The operand should only rollout when the observedConfig, the unsupportedConfigOverrides and the logLevel or other operand related parameter has changed or not.