### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -33,6 +33,7 @@ spec:
       name: openshift-controller-manager
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: openshift-controller-manager-a
         controller-manager: "true"

--- a/bindata/assets/openshift-controller-manager/route-controller-manager-deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/route-controller-manager-deploy.yaml
@@ -23,6 +23,7 @@ spec:
       name: route-controller-manager
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: route-controller-manager
         route-controller-manager: "true"

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       name: openshift-controller-manager-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: openshift-controller-manager-operator
     spec:


### PR DESCRIPTION
Affected workloads:
- `controller-manager` deployment
- `openshift-controller-manager-operator` deployment
- `route-controller-manager` deployment