### PR TITLE
OCPBUGS-34077: Always Disable Default Rolebindings Controller

### DIFF
--- a/pkg/operator/configobservation/controllers/observe_controllers.go
+++ b/pkg/operator/configobservation/controllers/observe_controllers.go
@@ -18,14 +18,18 @@ var allControllers = []string{
 	string(openshiftcontrolplanev1.OpenShiftBuildController),
 	string(openshiftcontrolplanev1.OpenShiftBuildConfigChangeController),
 	string(openshiftcontrolplanev1.OpenShiftBuilderServiceAccountController),
+	// OCPBUILD-9: the default rolebindings controller was refactored into separate controllers for
+	// the respective capability (Build, DeploymentConfig, ImageRegistry)
 	string(openshiftcontrolplanev1.OpenShiftBuilderRoleBindingsController),
 	string(openshiftcontrolplanev1.OpenShiftDeployerController),
 	string(openshiftcontrolplanev1.OpenShiftDeployerServiceAccountController),
+	// OCPBUILD-9: add rolebindings controller for deployer service account
 	string(openshiftcontrolplanev1.OpenShiftDeployerRoleBindingsController),
 	string(openshiftcontrolplanev1.OpenShiftDeploymentConfigController),
 	string(openshiftcontrolplanev1.OpenShiftImageTriggerController),
 	string(openshiftcontrolplanev1.OpenShiftImageImportController),
 	string(openshiftcontrolplanev1.OpenShiftImageSignatureImportController),
+	// OCPBUILD-9: add rolebindings controller to pull images from the internal registry
 	string(openshiftcontrolplanev1.OpenShiftImagePullerRoleBindingsController),
 	string(openshiftcontrolplanev1.OpenShiftTemplateInstanceController),
 	string(openshiftcontrolplanev1.OpenShiftTemplateInstanceFinalizerController),
@@ -38,7 +42,16 @@ var allControllers = []string{
 
 type disabledControllersFunc func(listers configobservation.Listers) ([]openshiftcontrolplanev1.OpenShiftControllerName, error)
 
+// disabledAlwaysControllers are legacy ocm controllers that are always disabled, regardless of
+// which cluster cababilities are enabled or disabled.
+func disabledAlwaysControllers(_ configobservation.Listers) ([]openshiftcontrolplanev1.OpenShiftControllerName, error) {
+	return []openshiftcontrolplanev1.OpenShiftControllerName{
+		openshiftcontrolplanev1.OpenShiftDefaultRoleBindingsController,
+	}, nil
+}
+
 var disabledControllerFuncs = []disabledControllersFunc{
+	disabledAlwaysControllers,
 	disabledImageRegistryControllers,
 	disabledBuildControllers,
 	disabledDeploymentConfigControllers,

--- a/pkg/operator/configobservation/controllers/observe_controllers_test.go
+++ b/pkg/operator/configobservation/controllers/observe_controllers_test.go
@@ -27,6 +27,8 @@ func TestObserveControllers(t *testing.T) {
 		for _, fn := range opts {
 			result = fn(result)
 		}
+		// The default rolebindings controller should always be disabled
+		result = withDisabled(openshiftcontrolplanev1.OpenShiftDefaultRoleBindingsController)(result)
 		controllersSort(result).Sort()
 		return result
 	}

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00.go
@@ -311,6 +311,14 @@ func disableControllers(clusterVersion *configv1.ClusterVersion) []string {
 	knownCaps := sets.New[configv1.ClusterVersionCapability](clusterVersion.Status.Capabilities.KnownCapabilities...)
 	capsEnabled := sets.New[configv1.ClusterVersionCapability](clusterVersion.Status.Capabilities.EnabledCapabilities...)
 
+	// OCPBUILD-8: the default pull secrets controller was refactored so each role binding can
+	// be matched with a cluster capability. The original default pull secrets controller was
+	// preserved to facilitate incremental upgrades. Starting in 4.16, the default pull secrets
+	// controller should be always be disabled to prevent race conditions and conflicts.
+
+	// TODO - the default rolebindings controller code should be removed in 4.17+
+	controllers = append(controllers, "-openshift.io/default-rolebindings")
+
 	for cont, cap := range controllerCapabilities {
 		if knownCaps.Has(cap) && !capsEnabled.Has(cap) {
 			controllers = append(controllers, fmt.Sprintf("-%s", cont))

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
@@ -67,6 +67,7 @@ func TestExpectedConfigMap(t *testing.T) {
 			"-openshift.io/build-config-change",
 			"-openshift.io/builder-rolebindings",
 			"-openshift.io/builder-serviceaccount",
+			"-openshift.io/default-rolebindings",
 		},
 		ServiceServingCert: openshiftcontrolplanev1.ServiceServingCert{},
 	}
@@ -135,7 +136,10 @@ func TestControllerDisabling(t *testing.T) {
 				configv1.ClusterVersionCapabilityDeploymentConfig,
 				configv1.ClusterVersionCapabilityImageRegistry,
 			},
-			result: map[string][]string{"controllers": {"*"}},
+			result: map[string][]string{
+				"controllers": {"*",
+					"-openshift.io/default-rolebindings",
+				}},
 		},
 		{
 			name: "BuildCapDisabled",
@@ -149,6 +153,7 @@ func TestControllerDisabling(t *testing.T) {
 					"-openshift.io/build-config-change",
 					"-openshift.io/builder-rolebindings",
 					"-openshift.io/builder-serviceaccount",
+					"-openshift.io/default-rolebindings",
 				}},
 		},
 		{
@@ -159,6 +164,7 @@ func TestControllerDisabling(t *testing.T) {
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
 				"controllers": {"*",
+					"-openshift.io/default-rolebindings",
 					"-openshift.io/deployer",
 					"-openshift.io/deployer-rolebindings",
 					"-openshift.io/deployer-serviceaccount",
@@ -173,6 +179,7 @@ func TestControllerDisabling(t *testing.T) {
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
 				"controllers": {"*",
+					"-openshift.io/default-rolebindings",
 					"-openshift.io/image-puller-rolebindings",
 					"-openshift.io/serviceaccount-pull-secrets",
 				}},
@@ -191,6 +198,7 @@ func TestControllerDisabling(t *testing.T) {
 					"-openshift.io/build-config-change",
 					"-openshift.io/builder-rolebindings",
 					"-openshift.io/builder-serviceaccount",
+					"-openshift.io/default-rolebindings",
 					"-openshift.io/deployer",
 					"-openshift.io/deployer-rolebindings",
 					"-openshift.io/deployer-serviceaccount",
@@ -203,7 +211,10 @@ func TestControllerDisabling(t *testing.T) {
 			name:                "CapabilitiesDisabledButUnknown",
 			knownCapabilities:   []v1.ClusterVersionCapability{},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
-			result:              map[string][]string{"controllers": {"*"}},
+			result: map[string][]string{
+				"controllers": {"*",
+					"-openshift.io/default-rolebindings",
+				}},
 		},
 	}
 


### PR DESCRIPTION
With OCPBUILD-7, default namespace rolebindings for the Image Registry, DeploymentConfig, and Builds are handled by separate controllers. The initial refactor in [OCPBUILD-8](https://issues.redhat.com//browse/OCPBUILD-8) kept the default rolebindings controller in place to allow upgrade from 4.15 -> 4.16. However, the corresponding operator change in [OCPBUILD-9](https://issues.redhat.com//browse/OCPBUILD-9) forgot to disable the default rolebindings controller. This leads to the following side effects:

- On clusters with no capabilities, the default role bindings are created and reconciled.
- On a standard installation, there is potential for race conditions and server-side conflicts as two or more controllers fight to reconcile a resource. At scale, this can lead to excessive load on the apiserver.

This change ensures that the default rolebindings controller is always disabled. As a follow-up, the code for the default rolebindings controller can be safely removed in OCP 4.17.