### PR TITLE
OCPBUGS-35801: nil pointer reference in ocm-operator

### DIFF
--- a/pkg/operator/internalimageregistry/cleanup_controller.go
+++ b/pkg/operator/internalimageregistry/cleanup_controller.go
@@ -143,7 +143,7 @@ func (c *imagePullSecretCleanupController) cleanup(ctx context.Context) error {
 				if errs.As(err, &statusErr) && statusErr.Status().Code == http.StatusConflict {
 					return factory.SyntheticRequeueError
 				}
-				return fmt.Errorf("unable to clean up references to the image pull secret %q (ns=%q) from the service accout %q: %w", imagePullSecret.Name, imagePullSecret.Namespace, serviceAccount.Name, err)
+				return fmt.Errorf("unable to clean up references to the image pull secret %q (ns=%q) from the service accout %q: %w", imagePullSecretName, serviceAccount.Namespace, serviceAccount.Name, err)
 			}
 		}
 		select {


### PR DESCRIPTION
Fix nil pointer reference.