### PR TITLE
[release-4.15] OCPBUGS-36152: Set required-scc for openshift workloads 

### DIFF
--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -33,6 +33,7 @@ spec:
       name: openshift-controller-manager
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: openshift-controller-manager-a
         controller-manager: "true"

--- a/bindata/assets/openshift-controller-manager/route-controller-manager-deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/route-controller-manager-deploy.yaml
@@ -23,6 +23,7 @@ spec:
       name: route-controller-manager
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         app: route-controller-manager
         route-controller-manager: "true"

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       name: openshift-controller-manager-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: openshift-controller-manager-operator
     spec:


### PR DESCRIPTION
manifests: set required-scc for openshift workloads
[OCPBUGS-36152](https://issues.redhat.com/browse/OCPBUGS-36152)
Manual cherry-pick of [#336](https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/336)