### PR TITLE
[release-4.12] OCPBUGS-41942, OCPBUGS-41943: Update opentelemetry to mitigate CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -108,7 +108,7 @@ require (
 )
 
 replace (
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 )

--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,8 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+replace (
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1205,4 +1205,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.0
+# go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0-unstable => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.44.0
 # vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787


### PR DESCRIPTION
This commit replaces following:

- go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc with relevant v0.46.0 [OCPBUGS-41942]
- go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp with relevant v0.44.0 [OCPBUGS-41943]