### PR TITLE
NO-JIRA: Remove marshaling in status apply

### DIFF
--- a/pkg/operator/generic_client.go
+++ b/pkg/operator/generic_client.go
@@ -2,16 +2,15 @@ package operator
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/openshift/library-go/pkg/apiserver/jsonpatch"
-
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 
 	operatorapiv1 "github.com/openshift/api/operator/v1"
 	v1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
@@ -141,60 +140,45 @@ func (p *genericClient) ApplyOperatorStatus(ctx context.Context, fieldManager st
 		return fmt.Errorf("applyConfiguration must have a value")
 	}
 
+	for i, val := range desiredConfiguration.Conditions {
+		// desired configuration may contain empty string fields.
+		// However, they are persisted by API server as nil. This causes a hotloop as empty string and nil
+		// are not equal. We explicitly convert empty strings to nil to prevent hotloop.
+		// This should be safe, because explicitly setting empty string has no meaning.
+		if len(ptr.Deref(val.Message, "")) == 0 {
+			desiredConfiguration.Conditions[i].Message = nil
+		}
+		if len(ptr.Deref(val.Reason, "")) == 0 {
+			desiredConfiguration.Conditions[i].Reason = nil
+		}
+	}
+
+	desiredStatus := &v1.OpenShiftControllerManagerStatusApplyConfiguration{
+		OperatorStatusApplyConfiguration: *desiredConfiguration,
+	}
 	desired := v1.OpenShiftControllerManager("cluster")
+	desired.WithStatus(desiredStatus)
 	instance, err := p.client.OpenShiftControllerManagers().Get(ctx, "cluster", metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 		// do nothing and proceed with the apply
-		v1helpers.SetApplyConditionsLastTransitionTime(p.clock, &desiredConfiguration.Conditions, nil)
-		desiredStatus := &v1.OpenShiftControllerManagerStatusApplyConfiguration{
-			OperatorStatusApplyConfiguration: *desiredConfiguration,
-		}
-		desired.WithStatus(desiredStatus)
+		v1helpers.SetApplyConditionsLastTransitionTime(p.clock, &desired.Status.Conditions, nil)
 	case err != nil:
 		return fmt.Errorf("unable to get operator configuration: %w", err)
 	default:
-		previous, err := v1.ExtractOpenShiftControllerManagerStatus(instance, fieldManager)
+		original, err := v1.ExtractOpenShiftControllerManagerStatus(instance, fieldManager)
 		if err != nil {
 			return fmt.Errorf("unable to extract operator configuration: %w", err)
 		}
 
-		operatorStatus := &v1.OperatorStatusApplyConfiguration{}
-		if previous.Status != nil {
-			jsonBytes, err := json.Marshal(previous.Status)
-			if err != nil {
-				return fmt.Errorf("unable to serialize operator configuration: %w", err)
-			}
-			if err := json.Unmarshal(jsonBytes, operatorStatus); err != nil {
-				return fmt.Errorf("unable to deserialize operator configuration: %w", err)
-			}
-		}
-
-		switch {
-		case desiredConfiguration.Conditions != nil && operatorStatus != nil:
-			v1helpers.SetApplyConditionsLastTransitionTime(p.clock, &desiredConfiguration.Conditions, operatorStatus.Conditions)
-		case desiredConfiguration.Conditions != nil && operatorStatus == nil:
-			v1helpers.SetApplyConditionsLastTransitionTime(p.clock, &desiredConfiguration.Conditions, nil)
-		}
-
-		v1helpers.CanonicalizeOperatorStatus(desiredConfiguration)
-		v1helpers.CanonicalizeOperatorStatus(operatorStatus)
-
-		original := v1.OpenShiftControllerManager("cluster")
-		if operatorStatus != nil {
-			originalStatus := &v1.OpenShiftControllerManagerStatusApplyConfiguration{
-				OperatorStatusApplyConfiguration: *operatorStatus,
-			}
-			original.WithStatus(originalStatus)
-		}
-
-		desiredStatus := &v1.OpenShiftControllerManagerStatusApplyConfiguration{
-			OperatorStatusApplyConfiguration: *desiredConfiguration,
-		}
-		desired.WithStatus(desiredStatus)
-
 		if equality.Semantic.DeepEqual(original, desired) {
 			return nil
+		}
+
+		if original.Status != nil {
+			v1helpers.SetApplyConditionsLastTransitionTime(clock.RealClock{}, &desired.Status.Conditions, original.Status.Conditions)
+		} else {
+			v1helpers.SetApplyConditionsLastTransitionTime(clock.RealClock{}, &desired.Status.Conditions, nil)
 		}
 	}
 


### PR DESCRIPTION
This PR removes unnecessary json marshal/unmarshal operation. Besides this PR sets condition's string fields to nil when they are passed empty string to prevent hotloop.