### PR TITLE
CNTRLPLANE-1544: Use user namespace for the operator

### DIFF
--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -19,13 +19,13 @@ spec:
       name: openshift-controller-manager-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: nonroot-v2
+        openshift.io/required-scc: restricted-v3
       labels:
         app: openshift-controller-manager-operator
     spec:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: openshift-controller-manager-operator


### PR DESCRIPTION
The operator now uses hostUsers: false in the associated deployment.
All relevant user and group IDs are set to 1000.

