### PR TITLE
no-jira: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/operator/configobservation/util.go
+++ b/pkg/operator/configobservation/util.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -74,7 +74,7 @@ func ConvertJSON(o interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	jsonEncoded, err := ioutil.ReadAll(buf)
+	jsonEncoded, err := io.ReadAll(buf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52