### PR TITLE
MON-4507: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/bindata/assets/openshift-controller-manager/route-controller-manager-servicemonitor-role.yaml
+++ b/bindata/assets/openshift-controller-manager/route-controller-manager-servicemonitor-role.yaml
@@ -14,3 +14,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/bindata/assets/openshift-controller-manager/servicemonitor-role.yaml
+++ b/bindata/assets/openshift-controller-manager/servicemonitor-role.yaml
@@ -14,3 +14,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_00_prometheusrole.yaml
@@ -20,3 +20,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_02_servicemonitor.yaml
@@ -27,3 +27,4 @@ spec:
   selector:
     matchLabels:
       app: openshift-controller-manager-operator
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_03_operand-servicemonitor.yaml
@@ -64,3 +64,4 @@ spec:
   selector:
     matchLabels:
       prometheus: openshift-controller-manager
+  serviceDiscoveryRole: EndpointSlice

--- a/manifests/0000_90_openshift-controller-manager-operator_04_operand-route-controller-servicemonitor.yaml
+++ b/manifests/0000_90_openshift-controller-manager-operator_04_operand-route-controller-servicemonitor.yaml
@@ -64,3 +64,4 @@ spec:
   selector:
     matchLabels:
       prometheus: route-controller-manager
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
