### PR TITLE
OCPBUGS-77404: bugfix: mount /etc/containers so image controllers respect cluster-wide image registry configurations

### DIFF
--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -69,6 +69,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: REGISTRY_AUTH_FILE
+          value: /var/run/secrets/image-auth/auth.json
         livenessProbe:
           initialDelaySeconds: 30
           httpGet:
@@ -95,6 +97,8 @@ spec:
         - mountPath: /etc/containers
           name: etc-containers
           readOnly: true
+        - mountPath: /var/run/secrets/image-auth
+          name: image-auth
       volumes:
       - name: config
         configMap:
@@ -117,6 +121,12 @@ spec:
           path: /etc/containers
           type: Directory
         name: etc-containers
+      - name: image-auth
+        secret:
+          secretName: pull-secret
+          items:
+            - key: .dockercfgjson
+              path: auth.json
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -39,9 +39,6 @@ spec:
         controller-manager: "true"
     spec:
       hostUsers: false
-      securityContext:
-        seccompProfile:
-          type: RuntimeDefault
       priorityClassName: system-node-critical
       serviceAccountName: openshift-controller-manager-sa
       containers:

--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -33,7 +33,7 @@ spec:
       name: openshift-controller-manager
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v3
+        openshift.io/required-scc: hostaccess
       labels:
         app: openshift-controller-manager-a
         controller-manager: "true"
@@ -92,6 +92,9 @@ spec:
           name: proxy-ca-bundles
         - mountPath: /tmp
           name: tmp
+        - mountPath: /etc/containers
+          name: etc-containers
+          readOnly: true
       volumes:
       - name: config
         configMap:
@@ -110,6 +113,10 @@ spec:
               path: tls-ca-bundle.pem
       - emptyDir: {}
         name: tmp
+      - hostPath:
+          path: /etc/containers
+          type: Directory
+        name: etc-containers
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/bindata/assets/openshift-controller-manager/deploy.yaml
+++ b/bindata/assets/openshift-controller-manager/deploy.yaml
@@ -122,7 +122,7 @@ spec:
         secret:
           secretName: pull-secret
           items:
-            - key: .dockercfgjson
+            - key: .dockerconfigjson
               path: auth.json
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/bindata/assets/openshift-controller-manager/ns.yaml
+++ b/bindata/assets/openshift-controller-manager/ns.yaml
@@ -8,3 +8,6 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
     openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/bindata/assets/openshift-controller-manager/scc-role.yaml
+++ b/bindata/assets/openshift-controller-manager/scc-role.yaml
@@ -1,0 +1,15 @@
+# needed to support host-mounted image registry configurations.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:openshift-controller-manager:hostaccess-role
+  namespace: openshift-controller-manager
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - hostaccess
+    verbs:
+      - use

--- a/bindata/assets/openshift-controller-manager/scc-rolebinding.yaml
+++ b/bindata/assets/openshift-controller-manager/scc-rolebinding.yaml
@@ -1,0 +1,13 @@
+# needed to support host-mounted image registry configurations.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: openshift-controller-manager
+  name: system:openshift-controller-manager:hostaccess-rolebinding
+roleRef:
+  kind: Role
+  name: system:openshift-controller-manager:hostaccess-role
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-controller-manager
+  name: openshift-controller-manager-sa

--- a/bindata/assets/openshift-controller-manager/scc-rolebinding.yaml
+++ b/bindata/assets/openshift-controller-manager/scc-rolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-controller-manager
   name: system:openshift-controller-manager:hostaccess-rolebinding
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: system:openshift-controller-manager:hostaccess-role
 subjects:

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -251,6 +251,9 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 			"assets/openshift-controller-manager/networkpolicy-default-deny.yaml",
 			"assets/openshift-controller-manager/route-controller-manager-networkpolicy-allow.yaml",
 			"assets/openshift-controller-manager/route-controller-manager-networkpolicy-default-deny.yaml",
+
+			"assets/openshift-controller-manager/scc-role.yaml",
+			"assets/openshift-controller-manager/scc-rolebinding.yaml",
 		},
 		resourceapply.NewKubeClientHolder(kubeClient),
 		opClient,

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -131,6 +131,14 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		controllerConfig.EventRecorder,
 	)
 
+	err = resourceSyncer.SyncSecret(
+		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "pull-secret"},
+		resourcesynccontroller.ResourceLocation{Namespace: util.TargetNamespace, Name: "pull-secret"},
+	)
+	if err != nil {
+		return fmt.Errorf("configuring global pull-secret syncing: %w", err)
+	}
+
 	if !cache.WaitForCacheSync(ctx.Done(), configInformers.Config().V1().ClusterVersions().Informer().HasSynced) {
 		klog.Errorf("timed out waiting for configInformers ClusterVersions")
 		return fmt.Errorf("timed out waiting for configInformers ClusterVersions")

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -132,8 +132,8 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	)
 
 	err = resourceSyncer.SyncSecret(
-		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "pull-secret"},
 		resourcesynccontroller.ResourceLocation{Namespace: util.TargetNamespace, Name: "pull-secret"},
+		resourcesynccontroller.ResourceLocation{Namespace: "openshift-config", Name: "pull-secret"},
 	)
 	if err != nil {
 		return fmt.Errorf("configuring global pull-secret syncing: %w", err)

--- a/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
+++ b/pkg/operator/sync_openshiftcontrollermanager_v311_00_test.go
@@ -44,7 +44,6 @@ import (
 )
 
 func TestExpectedConfigMap(t *testing.T) {
-
 	objects := []runtime.Object{
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-controller-manager"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
@@ -70,7 +69,8 @@ func TestExpectedConfigMap(t *testing.T) {
 		LeaderElection: configv1.LeaderElection{
 			Name: "openshift-master-controllers",
 		},
-		Controllers: []string{"*",
+		Controllers: []string{
+			"*",
 			"-openshift.io/build",
 			"-openshift.io/build-config-change",
 			"-openshift.io/builder-rolebindings",
@@ -124,7 +124,6 @@ func TestExpectedConfigMap(t *testing.T) {
 }
 
 func TestControllerDisabling(t *testing.T) {
-
 	testCases := []struct {
 		name                string
 		versionLister       configlisterv1.ClusterVersionLister
@@ -145,9 +144,11 @@ func TestControllerDisabling(t *testing.T) {
 				configv1.ClusterVersionCapabilityImageRegistry,
 			},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/default-rolebindings",
-				}},
+				},
+			},
 		},
 		{
 			name: "BuildCapDisabled",
@@ -156,13 +157,15 @@ func TestControllerDisabling(t *testing.T) {
 			},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/build",
 					"-openshift.io/build-config-change",
 					"-openshift.io/builder-rolebindings",
 					"-openshift.io/builder-serviceaccount",
 					"-openshift.io/default-rolebindings",
-				}},
+				},
+			},
 		},
 		{
 			name: "DeploymentConfigCapDisabled",
@@ -171,13 +174,15 @@ func TestControllerDisabling(t *testing.T) {
 			},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/default-rolebindings",
 					"-openshift.io/deployer",
 					"-openshift.io/deployer-rolebindings",
 					"-openshift.io/deployer-serviceaccount",
 					"-openshift.io/deploymentconfig",
-				}},
+				},
+			},
 		},
 		{
 			name: "ImageRegistryCapDisabled",
@@ -186,11 +191,13 @@ func TestControllerDisabling(t *testing.T) {
 			},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/default-rolebindings",
 					"-openshift.io/image-puller-rolebindings",
 					"-openshift.io/serviceaccount-pull-secrets",
-				}},
+				},
+			},
 		},
 		{
 			name: "CapabilitiesDisabled",
@@ -201,7 +208,8 @@ func TestControllerDisabling(t *testing.T) {
 			},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/build",
 					"-openshift.io/build-config-change",
 					"-openshift.io/builder-rolebindings",
@@ -213,16 +221,19 @@ func TestControllerDisabling(t *testing.T) {
 					"-openshift.io/deploymentconfig",
 					"-openshift.io/image-puller-rolebindings",
 					"-openshift.io/serviceaccount-pull-secrets",
-				}},
+				},
+			},
 		},
 		{
 			name:                "CapabilitiesDisabledButUnknown",
 			knownCapabilities:   []v1.ClusterVersionCapability{},
 			enabledCapabilities: []v1.ClusterVersionCapability{},
 			result: map[string][]string{
-				"controllers": {"*",
+				"controllers": {
+					"*",
 					"-openshift.io/default-rolebindings",
-				}},
+				},
+			},
 		},
 	}
 
@@ -623,7 +634,6 @@ type conditionTestCase struct {
 func testControllerManagerCondition(t *testing.T, conditionType string, testCases []conditionTestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			if len(tc.version) > 0 {
 				os.Setenv("RELEASE_VERSION", tc.version)
 			} else {
@@ -740,6 +750,10 @@ func TestDeploymentWithProxy(t *testing.T) {
 					},
 				},
 				{
+					Name:  "REGISTRY_AUTH_FILE",
+					Value: "/var/run/secrets/image-auth/auth.json",
+				},
+				{
 					Name:  "HTTPS_PROXY",
 					Value: "https://my-proxy",
 				},
@@ -771,6 +785,10 @@ func TestDeploymentWithProxy(t *testing.T) {
 							Name:  "POD_NAME",
 							Value: "my-pod",
 						},
+						{
+							Name:  "REGISTRY_AUTH_FILE",
+							Value: "/var/run/secrets/image-auth/auth.json",
+						},
 					}
 				}
 
@@ -797,6 +815,10 @@ func TestDeploymentWithProxy(t *testing.T) {
 				{
 					Name:  "POD_NAME",
 					Value: "my-pod",
+				},
+				{
+					Name:  "REGISTRY_AUTH_FILE",
+					Value: "/var/run/secrets/image-auth/auth.json",
 				},
 				// HTTPS_PROXY is added as it isn't in the template, but it's present in the proxy config.
 				{
@@ -874,7 +896,6 @@ func TestDeploymentWithProxy(t *testing.T) {
 				proxyLister,
 				specAnnotations,
 			)
-
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}


### PR DESCRIPTION
# Description

Fixes [OCPBUGS-77404](https://redhat.atlassian.net/browse/OCPBUGS-77404) by updating the `openshift-controller-manager` deployment to mount the `/etc/containers` directory from the host that the image controllers using the containers/image package will read for registry configurations.

The Machine Configuration Operator is responsible for syncing cluster configurations through the image APIs to this directory on the nodes.

In order to do this, the SCC needed to be adjusted to one that allowed host path mounting. To limit the changes as much as possible I updated the SCC to `hostaccess` from `restricted-v3` so that we can mount the host path but prevent running the container as `root`, maintaining the user namespace security boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Controller now requests the host-access security constraint; new role and rolebinding grant that access.
  * Operator synchronizes the cluster pull-secret into the controller namespace at startup.
  * Controller namespace annotated for privileged pod-security.
* **New Features**
  * Controller mounts host container configuration read-only and exposes a registry auth file via an environment variable for image pulls.
* **Tests**
  * Tests updated to expect the new registry auth env var and adjusted formatting in expected configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->